### PR TITLE
Change ShuntConductance to partial model

### DIFF
--- a/PowerGrids/Electrical/BaseClasses/ShuntConductance.mo
+++ b/PowerGrids/Electrical/BaseClasses/ShuntConductance.mo
@@ -1,6 +1,6 @@
 within PowerGrids.Electrical.BaseClasses;
 
-model ShuntConductance "Connects the port to ground via a conductor"
+partial model ShuntConductance "Connects the port to ground via a conductor"
   extends OnePortAC;
   Types.ComplexAdmittance Y "Shunt admittance";
   Types.ComplexVoltage v(re(nominal = port.VBase), im(nominal = port.VBase)) = port.v;


### PR DESCRIPTION
I suppose `ShuntConductance` is intended to be only a partial model as the number of equations and variables is not balanced.