### PR TITLE
Cosmetic changes

### DIFF
--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/PowerFlow.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/PowerFlow.mo
@@ -1,34 +1,34 @@
 within PowerGrids.Examples.Tutorial.GridOperation.Static;
 model PowerFlow "Power flow for the basic grid used in the tutorial"
   extends Modelica.Icons.Example;
-  PowerGrids.Electrical.PowerFlow.PVBus GEN(P = -4.75e+8, SNom = 5e+8, U = 20825.8, UNom = 21000, generatorConvention = false, portVariablesPhases = true, portVariablesPu = true)  annotation(
+  PowerGrids.Electrical.PowerFlow.PVBus GEN(P = -4.75e+8, SNom = 5e+8, U = 20825.8, UNom = 21000, generatorConvention = false, portVariablesPhases = true, portVariablesPu = true)  annotation (
     Placement(visible = true, transformation(origin = {-50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+8, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
+  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+8, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
     Placement(visible = true, transformation(origin = {-30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+8, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+8, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
     Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
+  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
     Placement(visible = true, transformation(origin = {30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  inner Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {110, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.PowerFlow.PQBus GRIDL(P = 4.75e+8, Q = 7.6e+7, SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
+    Placement(visible = true, transformation(origin = {-30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.PQBus GRIDL(P = 4.75e+8, Q = 7.6e+7, SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
     Placement(visible = true, transformation(origin = {60, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.PowerFlow.SlackBus GRID(SNom = 5e+8, U = 399000, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
+  PowerGrids.Electrical.PowerFlow.SlackBus GRID(SNom = 5e+8, U = 399000, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
     Placement(visible = true, transformation(origin = {60, 20}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
 equation
-  connect(GEN.terminal, NTLV.terminal) annotation(
+  connect(GEN.terminal, NTLV.terminal) annotation (
     Line(points = {{-50, 0}, {-30, 0}, {-30, 0}, {-30, 0}}));
-  connect(NTLV.terminal, TGEN.terminalA) annotation(
+  connect(NTLV.terminal, TGEN.terminalA) annotation (
     Line(points = {{-30, 0}, {-10, 0}, {-10, 0}, {-10, 0}}));
-  connect(TGEN.terminalB, NTHV.terminal) annotation(
+  connect(TGEN.terminalB, NTHV.terminal) annotation (
     Line(points = {{10, 0}, {30, 0}, {30, 0}, {30, 0}}));
-  connect(NTHV.terminal, GRID.terminal) annotation(
+  connect(NTHV.terminal, GRID.terminal) annotation (
     Line(points = {{30, 0}, {32, 0}, {32, 20}, {60, 20}, {60, 20}}));
-  connect(GRIDL.terminal, NTHV.terminal) annotation(
+  connect(GRIDL.terminal, NTHV.terminal) annotation (
     Line(points = {{60, -20}, {32, -20}, {32, 0}, {30, 0}}));
-  annotation(
-    Icon(coordinateSystem(grid = {0.1, 0.1})),
-    Diagram(coordinateSystem(extent = {{-100, -100}, {160, 100}}, grid = {0.5, 0.5})),
+  annotation (
+    Icon(coordinateSystem(grid={2,2}, extent={{-100,-100},{100,100}})),
+    Diagram(coordinateSystem(extent={{-60,-40},{80,40}},      grid={2,2})),
     experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-6, Interval = 0.002),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
     __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"));

--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGrid.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGrid.mo
@@ -1,42 +1,42 @@
 within PowerGrids.Examples.Tutorial.GridOperation.Static;
 model StaticGrid "System operating in steady-state with given inputs"
   extends Modelica.Icons.Example;
-  inner PowerGrids.Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-26, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {24, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {84, -20}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {54, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {110, -10}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, UStart = 399000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {104, -32}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu(y = 0.95)  annotation(
-    Placement(visible = true, transformation(origin = {-60, 4}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn(y = 2.50826)  annotation(
-    Placement(visible = true, transformation(origin = {-60, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
+    Placement(visible = true, transformation(origin = {62, 26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin = {-34, -2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {2, -22}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {38, -22}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin = {18, -22}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {64, -12}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, UStart = 399000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {58, -34}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu(y = 0.95)  annotation (
+    Placement(visible = true, transformation(origin = {-68, 2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn(y = 2.50826)  annotation (
+    Placement(visible = true, transformation(origin = {-68, -22}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(PmPu.y, GEN.PmPu) annotation(
-    Line(points = {{-48, 4}, {-38, 4}, {-38, 4}, {-36, 4}}, color = {0, 0, 127}));
-  connect(ufPuIn.y, GEN.ufPuIn) annotation(
-    Line(points = {{-48, -20}, {-44, -20}, {-44, -4}, {-36, -4}, {-36, -4}}, color = {0, 0, 127}));
-  connect(GRIDL.terminal, NTHV.terminal) annotation(
-    Line(points = {{104, -32}, {86, -32}, {86, -20}, {84, -20}, {84, -20}}));
-  connect(GEN.terminal, NTLV.terminal) annotation(
-    Line(points = {{-26, 0}, {-26, 0}, {-26, -20}, {24, -20}, {24, -20}}));
-  connect(NTLV.terminal, TGEN.terminalA) annotation(
-    Line(points = {{24, -20}, {44, -20}, {44, -20}, {44, -20}}));
-  connect(TGEN.terminalB, NTHV.terminal) annotation(
-    Line(points = {{64, -20}, {84, -20}, {84, -20}, {84, -20}}));
-  connect(NTHV.terminal, GRID.terminal) annotation(
-    Line(points = {{84, -20}, {86, -20}, {86, -10}, {110, -10}, {110, -10}}));
-  annotation(
-    Icon(coordinateSystem(grid = {0.1, 0.1})),
-    Diagram(coordinateSystem(grid = {0.5, 0.5}, extent = {{-100, -100}, {160, 100}})),
+  connect(PmPu.y, GEN.PmPu) annotation (
+    Line(points = {{-57, 2}, {-44, 2}}, color = {0, 0, 127}));
+  connect(ufPuIn.y, GEN.ufPuIn) annotation (
+    Line(points = {{-57, -22}, {-44, -22}, {-44, -6}}, color = {0, 0, 127}));
+  connect(GRIDL.terminal, NTHV.terminal) annotation (
+    Line(points = {{58, -34}, {58, -22}, {38, -22}}));
+  connect(GEN.terminal, NTLV.terminal) annotation (
+    Line(points = {{-34, -2}, {-34, -22}, {2, -22}}));
+  connect(NTLV.terminal, TGEN.terminalA) annotation (
+    Line(points = {{2, -22}, {8, -22}}));
+  connect(TGEN.terminalB, NTHV.terminal) annotation (
+    Line(points = {{28, -22}, {38, -22}}));
+  connect(NTHV.terminal, GRID.terminal) annotation (
+    Line(points = {{38, -22}, {64, -22}, {64, -12}}));
+  annotation (
+    Icon(coordinateSystem(grid={2,2}, extent={{-100,-100},{100,100}})),
+    Diagram(coordinateSystem(grid={2,2},        extent={{-80,-40},{80,40}})),
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
     __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"));

--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGridComputedParameters.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGridComputedParameters.mo
@@ -2,12 +2,10 @@ within PowerGrids.Examples.Tutorial.GridOperation.Static;
 model StaticGridComputedParameters "System operating in steady-state with computed inputs"
   extends StaticGrid(
     PmPu(y = -GEN.PStart / GEN.SNom),
-    ufPuIn(y = GEN.ufPuInStart)
-  );
-  annotation(
-    Icon(coordinateSystem(grid = {0.1, 0.1})),
-    Diagram(coordinateSystem(extent = {{-100, -100}, {180, 100}}, grid = {0.5, 0.5})),
+    ufPuIn(y = GEN.ufPuInStart));
+  annotation (
+    Diagram(coordinateSystem(extent={{-80,-40},{80,40}})),
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
-    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"));  
+    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"));
 end StaticGridComputedParameters;

--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGridDifferentGeneratorParam.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGridDifferentGeneratorParam.mo
@@ -1,110 +1,112 @@
 within PowerGrids.Examples.Tutorial.GridOperation.Static;
-
 model StaticGridDifferentGeneratorParam "Systems operating in steady-state with different generator parameterss"
   extends Modelica.Icons.Example;
-  inner PowerGrids.Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
+    Placement(visible = true, transformation(origin={95.5, 64},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
 // First Grid
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_1(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-116, 72}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV_1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-66, 52}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV_1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-2, 52}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_1(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {-36, 52}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID_1(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {20, 62}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_1(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {14, 40}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu_1(y = -GEN_1.PStart / GEN_1.SNom)  annotation(
-    Placement(visible = true, transformation(origin = {-150, 76}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn_1(y = GEN_1.ufPuInStart)  annotation(
-    Placement(visible = true, transformation(origin = {-150, 52}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_1(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin={-69.5, 50},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV_1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={-34.5, 34},  extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV_1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={11.5, 34},  extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_1(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin={-15, 34},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID_1(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={49.5, 48},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_1(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={47.5, 22},  extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu_1(y = -GEN_1.PStart / GEN_1.SNom)  annotation (
+    Placement(visible = true, transformation(origin={-103.5, 54},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn_1(y = GEN_1.ufPuInStart)  annotation (
+    Placement(visible = true, transformation(origin={-103.5, 35},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   // Second Grid - Transformer nominal voltage changed
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_2(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, excitationPuType = PowerGrids.Types.Choices.ExcitationPuType.Kundur, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-116, 12}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV_2(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-66, -8}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV_2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-2, -8}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_2(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {-36, -8}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID_2(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {20, 2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_2(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {14, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu_2(y = -GEN_2.PStart / GEN_2.SNom)  annotation(
-    Placement(visible = true, transformation(origin = {-150, 16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn_2(y = GEN_2.ufPuInStart)  annotation(
-    Placement(visible = true, transformation(origin = {-150, -8}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_2(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, excitationPuType = PowerGrids.Types.Choices.ExcitationPuType.Kundur, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin={-69.5, -6},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV_2(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={-34.5, -22},  extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV_2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={3.5, -22},    extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_2(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin={-14.5, -22},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID_2(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={51.5, -12},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_2(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={47.5, -30},  extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu_2(y = -GEN_2.PStart / GEN_2.SNom)  annotation (
+    Placement(visible = true, transformation(origin={-103.5, -2},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn_2(y = GEN_2.ufPuInStart)  annotation (
+    Placement(visible = true, transformation(origin={-103.5, -21},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
 // Third Grid - Generator Nominal Voltage changed
-  PowerGrids.Electrical.Machines.SynchronousMachine4WindingsInternalParameters GEN_3(H = 4, LDPu = 0.2, LQ1Pu = 0.444231, LQ2Pu = 0.2625, LdPu = 0.15, LfPu = 0.224242, LqPu = 0.15, MdPu = 1.85, MqPu = 1.65, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, mrcPu = 0, portVariablesPhases = true, rDPu = 0.0303152, rQ1Pu = 0.00308618, rQ2Pu = 0.0234897, raPu = 0, rfPu = 0.00128379)  annotation(
-    Placement(visible = true, transformation(origin = {-116, -48}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV_3(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-66, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV_3(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-4, -68}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_3(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {-36, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID_3(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {20, -58}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_3(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {14, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu_3(y = 0.95)  annotation(
-    Placement(visible = true, transformation(origin = {-150, -44}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn_3(y = 2.50826)  annotation(
-    Placement(visible = true, transformation(origin = {-150, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4WindingsInternalParameters GEN_3(H = 4, LDPu = 0.2, LQ1Pu = 0.444231, LQ2Pu = 0.2625, LdPu = 0.15, LfPu = 0.224242, LqPu = 0.15, MdPu = 1.85, MqPu = 1.65, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, mrcPu = 0, portVariablesPhases = true, rDPu = 0.0303152, rQ1Pu = 0.00308618, rQ2Pu = 0.0234897, raPu = 0, rfPu = 0.00128379)  annotation (
+    Placement(visible = true, transformation(origin={-69.5, -62},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV_3(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={-34.5, -78},  extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV_3(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={15.5, -78},  extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_3(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin={-4.5, -78},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID_3(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={51.5, -68},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_3(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={49.5, -90},  extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu_3(y = 0.95)  annotation (
+    Placement(visible = true, transformation(origin={-103.5, -58},  extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn_3(y = 2.50826)  annotation (
+    Placement(visible = true, transformation(origin={-103.5, -76.5},extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(PmPu_1.y, GEN_1.PmPu) annotation(
-    Line(points = {{-138, 76}, {-128, 76}, {-128, 76}, {-126, 76}}, color = {0, 0, 127}));
-  connect(ufPuIn_1.y, GEN_1.ufPuIn) annotation(
-    Line(points = {{-138, 52}, {-134, 52}, {-134, 68}, {-126, 68}, {-126, 68}}, color = {0, 0, 127}));
-  connect(PmPu_2.y, GEN_2.PmPu) annotation(
-    Line(points = {{-138, 16}, {-126, 16}, {-126, 16}, {-126, 16}}, color = {0, 0, 127}));
-  connect(ufPuIn_2.y, GEN_2.ufPuIn) annotation(
-    Line(points = {{-138, -8}, {-134, -8}, {-134, 8}, {-126, 8}, {-126, 8}}, color = {0, 0, 127}));
-  connect(PmPu_3.y, GEN_3.PmPu) annotation(
-    Line(points = {{-138, -44}, {-128, -44}, {-128, -44}, {-126, -44}}, color = {0, 0, 127}));
-  connect(ufPuIn_3.y, GEN_3.ufPuIn) annotation(
-    Line(points = {{-138, -68}, {-134, -68}, {-134, -52}, {-126, -52}, {-126, -52}}, color = {0, 0, 127}));
-  connect(GEN_1.terminal, NTLV_1.terminal) annotation(
-    Line(points = {{-116, 72}, {-116, 72}, {-116, 52}, {-66, 52}, {-66, 52}}));
-  connect(NTLV_1.terminal, TGEN_1.terminalA) annotation(
-    Line(points = {{-66, 52}, {-46, 52}, {-46, 52}, {-46, 52}}));
-  connect(TGEN_1.terminalB, NTHV_1.terminal) annotation(
-    Line(points = {{-26, 52}, {-2, 52}, {-2, 52}, {-2, 52}}));
-  connect(NTHV_1.terminal, GRID_1.terminal) annotation(
-    Line(points = {{-2, 52}, {4, 52}, {4, 62}, {20, 62}, {20, 62}}));
-  connect(NTHV_1.terminal, GRIDL_1.terminal) annotation(
-    Line(points = {{-2, 52}, {4, 52}, {4, 40}, {14, 40}, {14, 40}}));
-  connect(GEN_2.terminal, NTLV_2.terminal) annotation(
-    Line(points = {{-116, 12}, {-116, 12}, {-116, -8}, {-66, -8}, {-66, -8}}));
-  connect(NTLV_2.terminal, TGEN_2.terminalA) annotation(
-    Line(points = {{-66, -8}, {-46, -8}, {-46, -8}, {-46, -8}}));
-  connect(TGEN_2.terminalB, NTHV_2.terminal) annotation(
-    Line(points = {{-26, -8}, {-2, -8}, {-2, -8}, {-2, -8}}));
-  connect(NTHV_2.terminal, GRID_2.terminal) annotation(
-    Line(points = {{-2, -8}, {4, -8}, {4, 2}, {20, 2}, {20, 2}}));
-  connect(NTHV_2.terminal, GRIDL_2.terminal) annotation(
-    Line(points = {{-2, -8}, {4, -8}, {4, -20}, {14, -20}, {14, -20}}));
-  connect(GEN_3.terminal, NTLV_3.terminal) annotation(
-    Line(points = {{-116, -48}, {-116, -48}, {-116, -68}, {-66, -68}, {-66, -68}}));
-  connect(NTLV_3.terminal, TGEN_3.terminalA) annotation(
-    Line(points = {{-66, -68}, {-46, -68}, {-46, -68}, {-46, -68}}));
-  connect(TGEN_3.terminalB, NTHV_3.terminal) annotation(
-    Line(points = {{-26, -68}, {-4, -68}, {-4, -68}, {-4, -68}}));
-  connect(NTHV_3.terminal, GRID_3.terminal) annotation(
-    Line(points = {{-4, -68}, {2, -68}, {2, -58}, {20, -58}}));
-  connect(NTHV_3.terminal, GRIDL_3.terminal) annotation(
-    Line(points = {{-4, -68}, {2, -68}, {2, -80}, {14, -80}, {14, -80}}));
+  connect(PmPu_1.y, GEN_1.PmPu) annotation (
+    Line(points = {{-92.5, 54}, {-79.5, 54}}, color = {0, 0, 127}));
+  connect(ufPuIn_1.y, GEN_1.ufPuIn) annotation (
+    Line(points = {{-92.5, 35}, {-86.5, 35}, {-86.5, 46}, {-79.5, 46}}, color = {0, 0, 127}));
+  connect(PmPu_2.y, GEN_2.PmPu) annotation (
+    Line(points = {{-92.5, -2}, {-79.5, -2}}, color = {0, 0, 127}));
+  connect(ufPuIn_2.y, GEN_2.ufPuIn) annotation (
+    Line(points = {{-92.5, -21}, {-85.5, -21}, {-85.5, -10}, {-79.5, -10}}, color = {0, 0, 127}));
+  connect(PmPu_3.y, GEN_3.PmPu) annotation (
+    Line(points = {{-92.5, -58}, {-79.5, -58}}, color = {0, 0, 127}));
+  connect(ufPuIn_3.y, GEN_3.ufPuIn) annotation (
+    Line(points = {{-92.5, -76.5}, {-86, -76.5}, {-86, -65.5}, {-83, -65.5}, {-83, -66}, {-79.5, -66}}, color = {0, 0, 127}));
+  connect(GEN_1.terminal, NTLV_1.terminal) annotation (
+    Line(points = {{-69.5, 50}, {-69.5, 34}, {-34.5, 34}}));
+  connect(NTLV_1.terminal, TGEN_1.terminalA) annotation (
+    Line(points = {{-34.5, 34}, {-25, 34}}));
+  connect(TGEN_1.terminalB, NTHV_1.terminal) annotation (
+    Line(points = {{-5, 34}, {11.5, 34}}));
+  connect(NTHV_1.terminal, GRID_1.terminal) annotation (
+    Line(points = {{11.5, 34}, {35.5, 34}, {35.5, 48}, {49.5, 48}}));
+  connect(NTHV_1.terminal, GRIDL_1.terminal) annotation (
+    Line(points = {{11.5, 34}, {29.5, 34}, {29.5, 22}, {47.5, 22}}));
+  connect(GEN_2.terminal, NTLV_2.terminal) annotation (
+    Line(points = {{-69.5, -6}, {-69.5, -22}, {-34.5, -22}}));
+  connect(NTLV_2.terminal, TGEN_2.terminalA) annotation (
+    Line(points = {{-34.5, -22}, {-24.5, -22}}));
+  connect(TGEN_2.terminalB, NTHV_2.terminal) annotation (
+    Line(points = {{-4.5, -22}, {3.5, -22}}));
+  connect(NTHV_2.terminal, GRID_2.terminal) annotation (
+    Line(points = {{3.5, -22}, {35.5, -22}, {35.5, -12}, {51.5, -12}}));
+  connect(GEN_3.terminal, NTLV_3.terminal) annotation (
+    Line(points = {{-69.5, -62}, {-69.5, -78}, {-34.5, -78}}));
+  connect(NTLV_3.terminal, TGEN_3.terminalA) annotation (
+    Line(points = {{-34.5, -78}, {-14.5, -78}}));
+  connect(TGEN_3.terminalB, NTHV_3.terminal) annotation (
+    Line(points = {{5.5, -78}, {15.5, -78}}));
+  connect(NTHV_3.terminal, GRID_3.terminal) annotation (
+    Line(points = {{15.5, -78}, {35, -78}, {35, -68}, {51.5, -68}}));
+  connect(GRIDL_2.terminal, NTHV_2.terminal) annotation (
+    Line(points={{47.5,-30},{30.75,-30},{30.75,-22},{3.5,-22}}));
+  connect(GRIDL_3.terminal, NTHV_3.terminal) annotation (
+    Line(points={{49.5,-90},{30,-90},{30,-78},{15.5,-78}}));
 
-annotation(
+annotation (
      experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
     __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),
-    Diagram(coordinateSystem(extent = {{-200, -100}, {200, 100}}, grid = {0.5, 0.5}, initialScale = 0.1), graphics = {Text(origin = {81, 50}, extent = {{-33, 4}, {75, -12}}, textString = "generator parameters: time constant"), Text(origin = {81, -56}, extent = {{-37, 4}, {67, -28}}, textString = "generator parameters: physical"), Text(origin = {97, 8}, extent = {{-49, 4}, {87, -38}}, textString = "generator parameters: time constant - Kundur")}));
-
+    Diagram(coordinateSystem(extent={{-120,-100},{120,80}},      grid={2,2}),        graphics={Text(origin = {100.5, 28}, extent = {{-33, 4}, {17, -6}}, textString = "generator parameters:
+time constant"), Text(origin = {108.5, -58}, extent = {{-37, 4}, {5, -16}}, textString = "generator parameters:
+physical"), Text(origin = {118.5, -12}, extent = {{-49, 4}, {-3, -26}}, textString = "generator parameters:
+time constant - Kundur")}),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, grid={2,2})));
 end StaticGridDifferentGeneratorParam;

--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGridDifferentNominals.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGridDifferentNominals.mo
@@ -1,109 +1,109 @@
 within PowerGrids.Examples.Tutorial.GridOperation.Static;
 model StaticGridDifferentNominals "Systems operating in steady-state with different nominal values"
   extends Modelica.Icons.Example;
-  inner PowerGrids.Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
+    Placement(visible = true, transformation(origin = {70, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
 // First System
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_1(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-116, 72}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV_1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-66, 52}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV_1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-2, 52}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_1( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {-36, 52}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID_1(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {20, 62}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_1(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {14, 40}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu_1(y = -GEN_1.PStart / GEN_1.SNom)  annotation(
-    Placement(visible = true, transformation(origin = {-150, 76}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn_1(y = GEN_1.ufPuInStart)  annotation(
-    Placement(visible = true, transformation(origin = {-150, 52}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_1(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin = {-76, 64}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV_1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {-48, 44}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV_1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {4, 44}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_1( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin = {-24, 44}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID_1(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {26, 54}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_1(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {20, 32}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu_1(y = -GEN_1.PStart / GEN_1.SNom)  annotation (
+    Placement(visible = true, transformation(origin = {-108, 68}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn_1(y = GEN_1.ufPuInStart)  annotation (
+    Placement(visible = true, transformation(origin = {-108, 48}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   // Second System - Transformer nominal voltage changed
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_2(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-116, 12}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV_2(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-66, -8}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV_2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-2, -8}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_2( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 100000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {-36, -8}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID_2(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {20, 2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_2(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {14, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu_2(y = -GEN_2.PStart / GEN_2.SNom)  annotation(
-    Placement(visible = true, transformation(origin = {-150, 16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn_2(y = GEN_2.ufPuInStart)  annotation(
-    Placement(visible = true, transformation(origin = {-150, -8}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_2(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin = {-76, 18}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV_2(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {-48, -2}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV_2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {4, -2}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_2( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 100000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin = {-24, -2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID_2(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {26, 8}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_2(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {20, -14}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu_2(y = -GEN_2.PStart / GEN_2.SNom)  annotation (
+    Placement(visible = true, transformation(origin = {-108, 22}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn_2(y = GEN_2.ufPuInStart)  annotation (
+    Placement(visible = true, transformation(origin = {-108, 4}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
 // Third System - Generator Nominal Voltage changed
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_3(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 10000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-116, -48}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV_3(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-66, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV_3(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {-4, -68}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_3( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {-36, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID_3(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {20, -58}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_3(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {14, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu_3(y = -GEN_3.PStart / GEN_3.SNom)  annotation(
-    Placement(visible = true, transformation(origin = {-150, -44}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn_3(y = GEN_3.ufPuInStart)  annotation(
-    Placement(visible = true, transformation(origin = {-150, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN_3(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 10000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin = {-76, -38}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV_3(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {-48, -58}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV_3(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {2, -58}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN_3( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin = {-24, -58}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID_3(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {26, -48}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL_3(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {20, -70}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu_3(y = -GEN_3.PStart / GEN_3.SNom)  annotation (
+    Placement(visible = true, transformation(origin = {-108, -34}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn_3(y = GEN_3.ufPuInStart)  annotation (
+    Placement(visible = true, transformation(origin = {-108, -54}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(PmPu_1.y, GEN_1.PmPu) annotation(
-    Line(points = {{-138, 76}, {-128, 76}, {-128, 76}, {-126, 76}}, color = {0, 0, 127}));
-  connect(ufPuIn_1.y, GEN_1.ufPuIn) annotation(
-    Line(points = {{-138, 52}, {-134, 52}, {-134, 68}, {-126, 68}, {-126, 68}}, color = {0, 0, 127}));
-  connect(PmPu_2.y, GEN_2.PmPu) annotation(
-    Line(points = {{-138, 16}, {-126, 16}, {-126, 16}, {-126, 16}}, color = {0, 0, 127}));
-  connect(ufPuIn_2.y, GEN_2.ufPuIn) annotation(
-    Line(points = {{-138, -8}, {-134, -8}, {-134, 8}, {-126, 8}, {-126, 8}}, color = {0, 0, 127}));
-  connect(PmPu_3.y, GEN_3.PmPu) annotation(
-    Line(points = {{-138, -44}, {-128, -44}, {-128, -44}, {-126, -44}}, color = {0, 0, 127}));
-  connect(ufPuIn_3.y, GEN_3.ufPuIn) annotation(
-    Line(points = {{-138, -68}, {-134, -68}, {-134, -52}, {-126, -52}, {-126, -52}}, color = {0, 0, 127}));
-  connect(GEN_1.terminal, NTLV_1.terminal) annotation(
-    Line(points = {{-116, 72}, {-116, 72}, {-116, 52}, {-66, 52}, {-66, 52}}));
-  connect(NTLV_1.terminal, TGEN_1.terminalA) annotation(
-    Line(points = {{-66, 52}, {-46, 52}, {-46, 52}, {-46, 52}}));
-  connect(TGEN_1.terminalB, NTHV_1.terminal) annotation(
-    Line(points = {{-26, 52}, {-2, 52}, {-2, 52}, {-2, 52}}));
-  connect(NTHV_1.terminal, GRID_1.terminal) annotation(
-    Line(points = {{-2, 52}, {4, 52}, {4, 62}, {20, 62}, {20, 62}}));
-  connect(NTHV_1.terminal, GRIDL_1.terminal) annotation(
-    Line(points = {{-2, 52}, {4, 52}, {4, 40}, {14, 40}, {14, 40}}));
-  connect(GEN_2.terminal, NTLV_2.terminal) annotation(
-    Line(points = {{-116, 12}, {-116, 12}, {-116, -8}, {-66, -8}, {-66, -8}}));
-  connect(NTLV_2.terminal, TGEN_2.terminalA) annotation(
-    Line(points = {{-66, -8}, {-46, -8}, {-46, -8}, {-46, -8}}));
-  connect(TGEN_2.terminalB, NTHV_2.terminal) annotation(
-    Line(points = {{-26, -8}, {-2, -8}, {-2, -8}, {-2, -8}}));
-  connect(NTHV_2.terminal, GRID_2.terminal) annotation(
-    Line(points = {{-2, -8}, {4, -8}, {4, 2}, {20, 2}, {20, 2}}));
-  connect(NTHV_2.terminal, GRIDL_2.terminal) annotation(
-    Line(points = {{-2, -8}, {4, -8}, {4, -20}, {14, -20}, {14, -20}}));
-  connect(GEN_3.terminal, NTLV_3.terminal) annotation(
-    Line(points = {{-116, -48}, {-116, -48}, {-116, -68}, {-66, -68}, {-66, -68}}));
-  connect(NTLV_3.terminal, TGEN_3.terminalA) annotation(
-    Line(points = {{-66, -68}, {-46, -68}, {-46, -68}, {-46, -68}}));
-  connect(TGEN_3.terminalB, NTHV_3.terminal) annotation(
-    Line(points = {{-26, -68}, {-4, -68}, {-4, -68}, {-4, -68}}));
-  connect(NTHV_3.terminal, GRID_3.terminal) annotation(
-    Line(points = {{-4, -68}, {2, -68}, {2, -58}, {20, -58}}));
-  connect(NTHV_3.terminal, GRIDL_3.terminal) annotation(
-    Line(points = {{-4, -68}, {2, -68}, {2, -80}, {14, -80}, {14, -80}}));
+  connect(PmPu_1.y, GEN_1.PmPu) annotation (
+    Line(points = {{-97, 68}, {-86, 68}}, color = {0, 0, 127}));
+  connect(ufPuIn_1.y, GEN_1.ufPuIn) annotation (
+    Line(points = {{-97, 48}, {-93, 48}, {-93, 60}, {-86, 60}}, color = {0, 0, 127}));
+  connect(PmPu_2.y, GEN_2.PmPu) annotation (
+    Line(points = {{-97, 22}, {-86, 22}}, color = {0, 0, 127}));
+  connect(PmPu_3.y, GEN_3.PmPu) annotation (
+    Line(points = {{-97, -34}, {-86, -34}}, color = {0, 0, 127}));
+  connect(GEN_1.terminal, NTLV_1.terminal) annotation (
+    Line(points = {{-76, 64}, {-76, 44}, {-48, 44}}));
+  connect(NTLV_1.terminal, TGEN_1.terminalA) annotation (
+    Line(points = {{-48, 44}, {-34, 44}}));
+  connect(TGEN_1.terminalB, NTHV_1.terminal) annotation (
+    Line(points = {{-14, 44}, {4, 44}}));
+  connect(NTHV_1.terminal, GRID_1.terminal) annotation (
+    Line(points = {{4, 44}, {4, 54}, {26, 54}}));
+  connect(NTHV_1.terminal, GRIDL_1.terminal) annotation (
+    Line(points = {{4, 44}, {4, 32}, {20, 32}}));
+  connect(GEN_2.terminal, NTLV_2.terminal) annotation (
+    Line(points = {{-76, 18}, {-76, -2}, {-48, -2}}));
+  connect(NTLV_2.terminal, TGEN_2.terminalA) annotation (
+    Line(points = {{-48, -2}, {-34, -2}}));
+  connect(TGEN_2.terminalB, NTHV_2.terminal) annotation (
+    Line(points = {{-14, -2}, {4, -2}}));
+  connect(NTHV_2.terminal, GRID_2.terminal) annotation (
+    Line(points = {{4, -2}, {4, 8}, {26, 8}}));
+  connect(NTHV_2.terminal, GRIDL_2.terminal) annotation (
+    Line(points = {{4, -2}, {4, -14}, {20, -14}}));
+  connect(GEN_3.terminal, NTLV_3.terminal) annotation (
+    Line(points = {{-76, -38}, {-76, -58}, {-48, -58}}));
+  connect(NTLV_3.terminal, TGEN_3.terminalA) annotation (
+    Line(points = {{-48, -58}, {-34, -58}}));
+  connect(TGEN_3.terminalB, NTHV_3.terminal) annotation (
+    Line(points = {{-14, -58}, {2, -58}}));
+  connect(NTHV_3.terminal, GRID_3.terminal) annotation (
+    Line(points = {{2, -58}, {2, -48}, {26, -48}}));
+  connect(NTHV_3.terminal, GRIDL_3.terminal) annotation (
+    Line(points = {{2, -58}, {2, -70}, {20, -70}}));
+  connect(GEN_2.ufPuIn, ufPuIn_2.y) annotation (
+    Line(points = {{-86, 14}, {-94, 14}, {-94, 4}, {-97, 4}}, color = {0, 0, 127}));
+  connect(GEN_3.ufPuIn, ufPuIn_3.y) annotation (
+    Line(points = {{-86, -42}, {-94, -42}, {-94, -54}, {-97, -54}}, color = {0, 0, 127}));
 
-annotation(
+annotation (
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
-    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),        
-    Diagram(coordinateSystem(extent = {{-200, -100}, {200, 100}}, grid = {0.5, 0.5}), graphics = {Text(origin = {81, 50}, extent = {{-21, 4}, {21, -4}}, textString = "reference grid"), Text(origin = {97, 6}, extent = {{-37, 4}, {75, -36}}, textString = "transformer nominal voltage changed"), Text(origin = {97, -54}, extent = {{-37, 4}, {75, -36}}, textString = "generator nominal voltage changed")}));
-
+    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),
+    Diagram(coordinateSystem(extent={{-120,-80},{100,80}},      grid={2,2}),        graphics={  Text(origin = {65, 42}, extent = {{-21, 4}, {17, -6}}, textString = "reference grid"), Text(origin = {75, 6}, extent = {{-37, 4}, {21, -18}}, textString = "transformer\nnominal voltage changed"), Text(origin = {81, -50}, extent = {{-37, 4}, {17, -14}}, textString = "generator\nnominal voltage changed")}),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, grid={2,2})));
 end StaticGridDifferentNominals;


### PR DESCRIPTION
Several cosmetic changes on Tutorial examples.
The most important is to try to enhance the model visibility when shown in a small space. This is especially useful when you want to see a diagram window in the plotting view in OpernModelica.
In case this approach is accepted, I can make similar changes also for the other examples within the tutorial folder, and even more.