### PR TITLE
Replicate previous cosmetic changes into models in LoadChange

### DIFF
--- a/PowerGrids/Examples/Tutorial/GridOperation/LoadChange/LoadChangeByInputSignals.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/LoadChange/LoadChangeByInputSignals.mo
@@ -1,51 +1,51 @@
 within PowerGrids.Examples.Tutorial.GridOperation.LoadChange;
 model LoadChangeByInputSignals "Load step response specified by input signals"
   extends Modelica.Icons.Example;
-  inner PowerGrids.Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-26, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {24, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.BusFault NTHV(R = 0.05,SNom = 5e+08, UNom = 380000, UPhaseStart = 0, UStart = 1.050 * 380e3,portVariablesPhases = true, portVariablesPu = true, startTime = 1e10, stopTime = 1e10)  annotation(
-    Placement(visible = true, transformation(origin = {84, -20}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {54, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {110, -10}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQInputs GRIDL(SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {104, -32}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu(y = -GEN.PStart / GEN.SNom)  annotation(
-    Placement(visible = true, transformation(origin = {-60, 4}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn(y = GEN.ufPuInStart)  annotation(
-    Placement(visible = true, transformation(origin = {-60, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.Step PRef(height = 475e6 * 0.05, offset = 475e6, startTime = 2)  annotation(
-    Placement(visible = true, transformation(origin = {50, -50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.Step QRef(height = 76e6 * 0.04, offset = 76e6, startTime = 2) annotation(
-    Placement(visible = true, transformation(origin = {50, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
+    Placement(visible = true, transformation(origin={70,50},     extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin={-50,24},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={-30,4},     extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.BusFault NTHV(R = 0.05,SNom = 5e+08, UNom = 380000, UPhaseStart = 0, UStart = 1.050 * 380e3,portVariablesPhases = true, portVariablesPu = true, startTime = 1e10, stopTime = 1e10)  annotation (
+    Placement(visible = true, transformation(origin={30,4},      extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin={-2,4},      extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={56,14},      extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQInputs GRIDL(SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={50,-8},      extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu(y = -GEN.PStart / GEN.SNom)  annotation (
+    Placement(visible = true, transformation(origin={-88,28},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn(y = GEN.ufPuInStart)  annotation (
+    Placement(visible = true, transformation(origin={-88,4},      extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.Step PRef(height = 475e6 * 0.05, offset = 475e6, startTime = 2)  annotation (
+    Placement(visible = true, transformation(origin={10,-26},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.Step QRef(height = 76e6 * 0.04, offset = 76e6, startTime = 2) annotation (
+    Placement(visible = true, transformation(origin={-34,-44},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(PmPu.y, GEN.PmPu) annotation(
-    Line(points = {{-48, 4}, {-36, 4}, {-36, 4}, {-36, 4}}, color = {0, 0, 127}));
-  connect(ufPuIn.y, GEN.ufPuIn) annotation(
-    Line(points = {{-48, -20}, {-44, -20}, {-44, -4}, {-36, -4}, {-36, -4}}, color = {0, 0, 127}));
-  connect(GEN.terminal, NTLV.terminal) annotation(
-    Line(points = {{-26, 0}, {-26, 0}, {-26, -20}, {24, -20}, {24, -20}}));
-  connect(NTLV.terminal, TGEN.terminalA) annotation(
-    Line(points = {{24, -20}, {44, -20}, {44, -20}, {44, -20}}));
-  connect(TGEN.terminalB, NTHV.terminal) annotation(
-    Line(points = {{64, -20}, {82, -20}, {82, -20}, {84, -20}}));
-  connect(NTHV.terminal, GRID.terminal) annotation(
-    Line(points = {{84, -20}, {90, -20}, {90, -10}, {110, -10}, {110, -10}}));
-  connect(NTHV.terminal, GRIDL.terminal) annotation(
-    Line(points = {{84, -20}, {90, -20}, {90, -32}, {104, -32}, {104, -32}}));
-  connect(PRef.y, GRIDL.PRefIn) annotation(
-    Line(points = {{62, -50}, {108, -50}, {108, -42}, {108, -42}}, color = {0, 0, 127}));
-  connect(QRef.y, GRIDL.QRefIn) annotation(
-    Line(points = {{62, -80}, {114, -80}, {114, -42}, {114, -42}}, color = {0, 0, 127}));
+  connect(PmPu.y, GEN.PmPu) annotation (
+    Line(points={{-77,28},{-60,28}},                        color = {0, 0, 127}));
+  connect(ufPuIn.y, GEN.ufPuIn) annotation (
+    Line(points={{-77,4},{-72,4},{-72,20},{-60,20}},                         color = {0, 0, 127}));
+  connect(GEN.terminal, NTLV.terminal) annotation (
+    Line(points={{-50,24},{-50,4},{-30,4}}));
+  connect(NTLV.terminal, TGEN.terminalA) annotation (
+    Line(points={{-30,4},{-12,4}}));
+  connect(TGEN.terminalB, NTHV.terminal) annotation (
+    Line(points={{8,4},{30,4}}));
+  connect(NTHV.terminal, GRID.terminal) annotation (
+    Line(points={{30,4},{36,4},{36,14},{56,14}}));
+  connect(NTHV.terminal, GRIDL.terminal) annotation (
+    Line(points={{30,4},{36,4},{36,-8},{50,-8}}));
+  connect(PRef.y, GRIDL.PRefIn) annotation (
+    Line(points={{21,-26},{54,-26},{54,-18}},                      color = {0, 0, 127}));
+  connect(QRef.y, GRIDL.QRefIn) annotation (
+    Line(points={{-23,-44},{60,-44},{60,-18}},                     color = {0, 0, 127}));
 
-annotation(
+annotation (
     experiment(StartTime = 0, StopTime = 4, Tolerance = 1e-6, Interval = 0.008),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
-    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),  Diagram(coordinateSystem(extent = {{-100, -100}, {160, 100}})));
-    
+    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),  Diagram(coordinateSystem(extent={{-100,
+            -60},{80,60}})));
 end LoadChangeByInputSignals;

--- a/PowerGrids/Examples/Tutorial/GridOperation/LoadChange/LoadChangeByModifier.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/LoadChange/LoadChangeByModifier.mo
@@ -1,51 +1,56 @@
 within PowerGrids.Examples.Tutorial.GridOperation.LoadChange;
 model LoadChangeByModifier "Load step response specified by modifiers on a copy of the static system"
   extends Modelica.Icons.Example;
-  inner PowerGrids.Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation(
-    Placement(visible = true, transformation(origin = {-26, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {24, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {84, -20}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation(
-    Placement(visible = true, transformation(origin = {54, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {110, -10}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
+    Placement(visible = true, transformation(origin={50,30},     extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
+    Placement(visible = true, transformation(origin={-26,6},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={-6,-16},    extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={42,-16},    extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN(PStartA = 4.75e+08, PStartB = -4.75e+08, QStartA = 1.56e+08, QStartB = -7.6e+07, R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, UPhaseStartA = 0.161156, UPhaseStartB = 0, UStartA = 0.9917 * 21e3, UStartB = 0.95227 * 380e3, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin={16,-16},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={68,-6},      extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL(
       PRef = 4.75e+08*(if time < 2 then 1 else 1.05) "Active power consumption at reference voltage",
       QRef = 7.6e+07*(if time < 2 then 1 else 1.04) "Reactive power consumption at reference voltage",
-      SNom = 5e+08, 
-      UNom = 380000, 
-      URef = 1.05 * 380e3, 
-      portVariablesPhases = true, 
-      portVariablesPu = true)  annotation(
-    Placement(visible = true, transformation(origin = {104, -32}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Sources.RealExpression PmPu(y = -GEN.PStart / GEN.SNom)  annotation(
-    Placement(visible = true, transformation(origin = {-60, 4}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression ufPuIn(y = GEN.ufPuInStart)  annotation(
-    Placement(visible = true, transformation(origin = {-60, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+      SNom = 5e+08,
+      UNom = 380000,
+      URef = 1.05 * 380e3,
+      portVariablesPhases = true,
+      portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin={62,-28},     extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Sources.RealExpression PmPu(y = -GEN.PStart / GEN.SNom)  annotation (
+    Placement(visible = true, transformation(origin={-60,10},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Sources.RealExpression ufPuIn(y = GEN.ufPuInStart)  annotation (
+    Placement(visible = true, transformation(origin={-60,-14},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
 equation
-  connect(PmPu.y, GEN.PmPu) annotation(
-    Line(points = {{-48, 4}, {-38, 4}, {-38, 4}, {-36, 4}}, color = {0, 0, 127}));
-  connect(ufPuIn.y, GEN.ufPuIn) annotation(
-    Line(points = {{-48, -20}, {-44, -20}, {-44, -4}, {-36, -4}, {-36, -4}}, color = {0, 0, 127}));
-  connect(GRIDL.terminal, NTHV.terminal) annotation(
-    Line(points = {{104, -32}, {86, -32}, {86, -20}, {84, -20}, {84, -20}}));
-  connect(GEN.terminal, NTLV.terminal) annotation(
-    Line(points = {{-26, 0}, {-26, 0}, {-26, -20}, {24, -20}, {24, -20}}));
-  connect(NTLV.terminal, TGEN.terminalA) annotation(
-    Line(points = {{24, -20}, {44, -20}, {44, -20}, {44, -20}}));
-  connect(TGEN.terminalB, NTHV.terminal) annotation(
-    Line(points = {{64, -20}, {84, -20}, {84, -20}, {84, -20}}));
-  connect(NTHV.terminal, GRID.terminal) annotation(
-    Line(points = {{84, -20}, {86, -20}, {86, -10}, {110, -10}, {110, -10}}));
-  
-annotation(
+  connect(PmPu.y, GEN.PmPu) annotation (
+    Line(points={{-49,10},{-36,10}},                        color = {0, 0, 127}));
+  connect(ufPuIn.y, GEN.ufPuIn) annotation (
+    Line(points={{-49,-14},{-44,-14},{-44,2},{-36,2}},                       color = {0, 0, 127}));
+  connect(GRIDL.terminal, NTHV.terminal) annotation (
+    Line(points={{62,-28},{44,-28},{44,-16},{42,-16}}));
+  connect(GEN.terminal, NTLV.terminal) annotation (
+    Line(points={{-26,6},{-26,-16},{-6,-16}}));
+  connect(NTLV.terminal, TGEN.terminalA) annotation (
+    Line(points={{-6,-16},{6,-16}}));
+  connect(TGEN.terminalB, NTHV.terminal) annotation (
+    Line(points={{26,-16},{42,-16}}));
+  connect(NTHV.terminal, GRID.terminal) annotation (
+    Line(points={{42,-16},{44,-16},{44,-6},{68,-6}}));
+
+annotation (
     experiment(StartTime = 0, StopTime = 4, Tolerance = 1e-6, Interval = 0.008),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
     __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),
-  Diagram(coordinateSystem(extent = {{-100, -100}, {180, 100}}, grid = {0.5, 0.5}), graphics = {Text(origin = {106, -48}, extent = {{-46, 8}, {54, -12}}, textString = "Load change is made in text view")}));
+  Diagram(coordinateSystem(extent={{-80,-60},{80,40}}),                             graphics={  Text(origin={
+              -2.2,-48},                                                                                                  extent={{
+              -59.8,8},{70.2,-12}},
+          textString="To see load change in OpenModelica look at text view",
+          lineColor={0,0,0})}),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, grid={2,2})));
 end LoadChangeByModifier;

--- a/PowerGrids/Examples/Tutorial/GridOperation/LoadChange/LoadChangeByModifierUsingExtends.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/LoadChange/LoadChangeByModifierUsingExtends.mo
@@ -3,11 +3,14 @@ model LoadChangeByModifierUsingExtends "Load step response specified by modifier
   extends Examples.Tutorial.GridOperation.Static.StaticGridComputedParameters(
     GRIDL(
       PRef = GRIDL.PRefConst*(if time < 2 then 1 else 1.05) "Active power consumption at reference voltage",
-      QRef = GRIDL.QRefConst*(if time < 2 then 1 else 1.04) "Reactive power consumption at reference voltage"
-    )
-  );  
-annotation(
+      QRef = GRIDL.QRefConst*(if time < 2 then 1 else 1.04) "Reactive power consumption at reference voltage"));
+annotation (
     experiment(StartTime = 0, StopTime = 4, Tolerance = 1e-6, Interval = 0.008),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
-    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),  Diagram(coordinateSystem(extent = {{-100, -100}, {180, 100}}, grid = {0.5, 0.5}), graphics = {Text(origin = {106, -48}, extent = {{-46, 8}, {54, -12}}, textString = "Load change is made in text view")}));
+    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"),  Diagram(coordinateSystem(extent={{-80,-60},
+            {80,40}}), graphics={                                                               Text(origin={
+              -10.2,-46},                                                                                                 extent={{
+              -59.8,8},{70.2,-12}},
+          textString="To see load change in OpenModelica look at text view",
+          lineColor={0,0,0})}));
 end LoadChangeByModifierUsingExtends;

--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGrid.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/StaticGrid.mo
@@ -4,36 +4,36 @@ model StaticGrid "System operating in steady-state with given inputs"
   inner PowerGrids.Electrical.System systemPowerGrids annotation (
     Placement(visible = true, transformation(origin = {62, 26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08,SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0.161156, UStart = 21e3 * 0.9917, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8)  annotation (
-    Placement(visible = true, transformation(origin = {-34, -2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin={-34,2},     extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {2, -22}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+    Placement(visible = true, transformation(origin={2,-18},    extent = {{-10, -10}, {10, 10}}, rotation = 90)));
   PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {38, -22}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+    Placement(visible = true, transformation(origin={38,-18},    extent = {{-10, 10}, {10, -10}}, rotation = 90)));
   PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
-    Placement(visible = true, transformation(origin = {18, -22}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin={18,-18},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1 / 10, SNom = 5e+08, SSC = 2.5e+09, UNom = 380000, URef = 1.05 * 380e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {64, -12}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin={64,-8},     extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, UPhaseStart = 0, URef = 1.05 * 380e3, UStart = 399000, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {58, -34}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+    Placement(visible = true, transformation(origin={58,-30},    extent = {{-10, -10}, {10, 10}}, rotation = 90)));
   Modelica.Blocks.Sources.RealExpression PmPu(y = 0.95)  annotation (
-    Placement(visible = true, transformation(origin = {-68, 2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin={-64,6},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Sources.RealExpression ufPuIn(y = 2.50826)  annotation (
-    Placement(visible = true, transformation(origin = {-68, -22}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin={-64,-18},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
   connect(PmPu.y, GEN.PmPu) annotation (
-    Line(points = {{-57, 2}, {-44, 2}}, color = {0, 0, 127}));
+    Line(points={{-53,6},{-44,6}},      color = {0, 0, 127}));
   connect(ufPuIn.y, GEN.ufPuIn) annotation (
-    Line(points = {{-57, -22}, {-44, -22}, {-44, -6}}, color = {0, 0, 127}));
+    Line(points={{-53,-18},{-44,-18},{-44,-2}},        color = {0, 0, 127}));
   connect(GRIDL.terminal, NTHV.terminal) annotation (
-    Line(points = {{58, -34}, {58, -22}, {38, -22}}));
+    Line(points={{58,-30},{58,-18},{38,-18}}));
   connect(GEN.terminal, NTLV.terminal) annotation (
-    Line(points = {{-34, -2}, {-34, -22}, {2, -22}}));
+    Line(points={{-34,2},{-34,-18},{2,-18}}));
   connect(NTLV.terminal, TGEN.terminalA) annotation (
-    Line(points = {{2, -22}, {8, -22}}));
+    Line(points={{2,-18},{8,-18}}));
   connect(TGEN.terminalB, NTHV.terminal) annotation (
-    Line(points = {{28, -22}, {38, -22}}));
+    Line(points={{28,-18},{38,-18}}));
   connect(NTHV.terminal, GRID.terminal) annotation (
-    Line(points = {{38, -22}, {64, -22}, {64, -12}}));
+    Line(points={{38,-18},{64,-18},{64,-8}}));
   annotation (
     Icon(coordinateSystem(grid={2,2}, extent={{-100,-100},{100,100}})),
     Diagram(coordinateSystem(grid={2,2},        extent={{-80,-40},{80,40}})),


### PR DESCRIPTION
This is a follow-up to PR #11: There we applied some cosmetic changes to some Tutorial examples. Here the same style is applied to other tutorial examples, i.e. those in the LoadChange Tutorial.GridOperation.LoadChange, and one parent model.