### PR TITLE
Better implementation of HV Gate block in IEEE AC4a regulator

### DIFF
--- a/PowerGrids/Electrical/Controls/ExcitationSystems/IEEE_AC4A.mo
+++ b/PowerGrids/Electrical/Controls/ExcitationSystems/IEEE_AC4A.mo
@@ -32,7 +32,7 @@ block IEEE_AC4A "Static excitation system - IEEE type AC4A"
     Placement(visible = true, transformation(origin={10,0},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Controls.FirstOrderWithNonWindupLimiter firstOrderLim(T = Ta, initType = Modelica.Blocks.Types.Init.SteadyState, k = Ka, yMax = VrMax, yMin = VrMin, yStart = 1)  annotation (
     Placement(visible = true, transformation(origin={86,0},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Math.Max max1
+  Modelica.Blocks.Math.Max max
     annotation (Placement(transformation(extent={{40,-10},{60,10}})));
 initial equation
   /* The following equation could be written as
@@ -71,11 +71,11 @@ equation
     Line(points={{-122,30},{-90,30},{-90,8},{-78,8}},                      color = {0, 0, 127}));
   connect(VcPu, addIng.u2) annotation (
     Line(points={{-122,0},{-78,0}},                          color = {0, 0, 127}));
-  connect(max1.u1, leadLag.y)
+  connect(max.u1, leadLag.y)
     annotation (Line(points={{38,6},{30,6},{30,0},{21,0}}, color={0,0,127}));
-  connect(max1.u2, VuelPu) annotation (Line(points={{38,-6},{30,-6},{30,-40},{2,
+  connect(max.u2, VuelPu) annotation (Line(points={{38,-6},{30,-6},{30,-40},{2,
           -40}}, color={0,0,127}));
-  connect(max1.y, firstOrderLim.u)
+  connect(max.y, firstOrderLim.u)
     annotation (Line(points={{61,0},{74,0}}, color={0,0,127}));
   annotation (
     Icon(graphics={  Rectangle(origin = {0, 1}, extent = {{-100, 99}, {100, -101}}), Text(origin = {24, 4}, extent = {{-94, 70}, {56, -72}}, textString = "IEEE

--- a/PowerGrids/Electrical/Controls/ExcitationSystems/IEEE_AC4A.mo
+++ b/PowerGrids/Electrical/Controls/ExcitationSystems/IEEE_AC4A.mo
@@ -14,28 +14,26 @@ block IEEE_AC4A "Static excitation system - IEEE type AC4A"
   parameter SI.PerUnit oversaturationPu = 0.1 "abs(u-usat)/(Vmax-Vmin) in case of saturated initial condition" annotation(Dialog(enable = fixInitialControlledVariable));
   final parameter Real delta = (inputLimiter.uMax-inputLimiter.uMin)*oversaturationPu "Actuator saturation margin";
 
-  Modelica.Blocks.Interfaces.RealInput VsPu "PSS output p.u" annotation(
-    Placement(visible = true, transformation(origin = {-140, 30}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealInput VcPu "Machine terminal voltage p.u." annotation(
-    Placement(visible = true, transformation(origin = {-140, 0}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealInput VrefPu "Voltage reference p.u." annotation(
-    Placement(visible = true, transformation(origin = {-140, -30}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealInput VuelPu "Underexcitation limit p.u." annotation(
-    Placement(visible = true, transformation(origin = {-8, -40}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealOutput efdPu "Exciter output voltage p.u." annotation(
-    Placement(visible = true, transformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Math.Add3 addIng(k1 = +1, k2 = -1, k3 = +1)  annotation(
-    Placement(visible = true, transformation(origin = {-80, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.Limiter inputLimiter(limitsAtInit = true, uMax = ViMax, uMin = ViMin)  annotation(
-    Placement(visible = true, transformation(origin = {-40, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Controls.LeadLag leadLag(T1 = Tc, T2 = Tb, initType = Modelica.Blocks.Types.Init.SteadyState, k = 1, yStart = 1 / Ka)  annotation(
-    Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Controls.FirstOrderWithNonWindupLimiter firstOrderLim(T = Ta, initType = Modelica.Blocks.Types.Init.SteadyState, k = Ka, yMax = VrMax, yMin = VrMin, yStart = 1)  annotation(
-    Placement(visible = true, transformation(origin = {80, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter annotation(
-    Placement(visible = true, transformation(origin = {42, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.Constant largeReal(k = 1e9)  annotation(
-    Placement(visible = true, transformation(origin = {0, 40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput VsPu "PSS output p.u" annotation (
+    Placement(visible = true, transformation(origin={-122,30},    extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput VcPu "Machine terminal voltage p.u." annotation (
+    Placement(visible = true, transformation(origin={-122,0},    extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput VrefPu "Voltage reference p.u." annotation (
+    Placement(visible = true, transformation(origin={-122,-30},    extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput VuelPu "Underexcitation limit p.u." annotation (
+    Placement(visible = true, transformation(origin={2,-40},     extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput efdPu "Exciter output voltage p.u." annotation (
+    Placement(visible = true, transformation(origin={116,0},    extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin={116,0},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Math.Add3 addIng(k1 = +1, k2 = -1, k3 = +1)  annotation (
+    Placement(visible = true, transformation(origin={-66,0},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Nonlinear.Limiter inputLimiter(limitsAtInit = true, uMax = ViMax, uMin = ViMin)  annotation (
+    Placement(visible = true, transformation(origin={-30,0},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Controls.LeadLag leadLag(T1 = Tc, T2 = Tb, initType = Modelica.Blocks.Types.Init.SteadyState, k = 1, yStart = 1 / Ka)  annotation (
+    Placement(visible = true, transformation(origin={10,0},   extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Controls.FirstOrderWithNonWindupLimiter firstOrderLim(T = Ta, initType = Modelica.Blocks.Types.Init.SteadyState, k = Ka, yMax = VrMax, yMin = VrMin, yStart = 1)  annotation (
+    Placement(visible = true, transformation(origin={86,0},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Math.Max max1
+    annotation (Placement(transformation(extent={{40,-10},{60,10}})));
 initial equation
   /* The following equation could be written as
  
@@ -61,30 +59,28 @@ initial equation
       simplified = VcPu - VcPuStart);
   end if;
 equation
-  connect(firstOrderLim.y, efdPu) annotation(
-    Line(points = {{92, 0}, {106, 0}, {106, 0}, {110, 0}}, color = {0, 0, 127}));
-  connect(inputLimiter.y, leadLag.u) annotation(
-    Line(points = {{-28, 0}, {-12, 0}, {-12, 0}, {-12, 0}}, color = {0, 0, 127}));
-  connect(addIng.y, inputLimiter.u) annotation(
-    Line(points = {{-68, 0}, {-52, 0}, {-52, 0}, {-52, 0}}, color = {0, 0, 127}));
-  connect(VrefPu, addIng.u3) annotation(
-    Line(points = {{-140, -30}, {-108, -30}, {-108, -8}, {-92, -8}, {-92, -8}}, color = {0, 0, 127}));
-  connect(VsPu, addIng.u1) annotation(
-    Line(points = {{-140, 30}, {-108, 30}, {-108, 8}, {-92, 8}, {-92, 8}}, color = {0, 0, 127}));
-  connect(VcPu, addIng.u2) annotation(
-    Line(points = {{-140, 0}, {-94, 0}, {-94, 0}, {-92, 0}}, color = {0, 0, 127}));
-  connect(variableLimiter.y, firstOrderLim.u) annotation(
-    Line(points = {{53, 0}, {68, 0}}, color = {0, 0, 127}));
-  connect(leadLag.y, variableLimiter.u) annotation(
-    Line(points = {{12, 0}, {30, 0}}, color = {0, 0, 127}));
-  connect(largeReal.y, variableLimiter.limit1) annotation(
-    Line(points = {{11, 40}, {20, 40}, {20, 8}, {30, 8}}, color = {0, 0, 127}));
-  connect(VuelPu, variableLimiter.limit2) annotation(
-    Line(points = {{-8, -40}, {22, -40}, {22, -8}, {30, -8}}, color = {0, 0, 127}));
-  annotation(
-    Icon(coordinateSystem(grid = {0.1, 0.1}, initialScale = 0.1), graphics = {Rectangle(origin = {0, 1}, extent = {{-100, 99}, {100, -101}}), Text(origin = {24, 4}, extent = {{-94, 70}, {56, -72}}, textString = "IEEE
+  connect(firstOrderLim.y, efdPu) annotation (
+    Line(points={{97,0},{116,0}},                          color = {0, 0, 127}));
+  connect(inputLimiter.y, leadLag.u) annotation (
+    Line(points={{-19,0},{-2,0}},                           color = {0, 0, 127}));
+  connect(addIng.y, inputLimiter.u) annotation (
+    Line(points={{-55,0},{-42,0}},                          color = {0, 0, 127}));
+  connect(VrefPu, addIng.u3) annotation (
+    Line(points={{-122,-30},{-90,-30},{-90,-8},{-78,-8}},                       color = {0, 0, 127}));
+  connect(VsPu, addIng.u1) annotation (
+    Line(points={{-122,30},{-90,30},{-90,8},{-78,8}},                      color = {0, 0, 127}));
+  connect(VcPu, addIng.u2) annotation (
+    Line(points={{-122,0},{-78,0}},                          color = {0, 0, 127}));
+  connect(max1.u1, leadLag.y)
+    annotation (Line(points={{38,6},{30,6},{30,0},{21,0}}, color={0,0,127}));
+  connect(max1.u2, VuelPu) annotation (Line(points={{38,-6},{30,-6},{30,-40},{2,
+          -40}}, color={0,0,127}));
+  connect(max1.y, firstOrderLim.u)
+    annotation (Line(points={{61,0},{74,0}}, color={0,0,127}));
+  annotation (
+    Icon(graphics={  Rectangle(origin = {0, 1}, extent = {{-100, 99}, {100, -101}}), Text(origin = {24, 4}, extent = {{-94, 70}, {56, -72}}, textString = "IEEE
 AC4A"), Text(origin = {0, 120}, lineColor = {0, 0, 255}, extent = {{-80, 14}, {80, -14}}, textString = "%name")}),
-    Diagram(coordinateSystem(extent = {{-200, -100}, {200, 100}})),
+    Diagram(coordinateSystem(extent={{-120,-60},{120,60}})),
   Documentation(info = "<html>
 <p>The class implements a model of a static exictation system according to the IEEE Std 421.5TM-2005.</p>
 <p>The type implemented is the AC4A, described in the chapter 6.4 of the same IEEE Std 421.5TM-2005.</p>

--- a/PowerGrids/Examples/ENTSOE/TestCase1.mo
+++ b/PowerGrids/Examples/ENTSOE/TestCase1.mo
@@ -1,54 +1,56 @@
 within PowerGrids.Examples.ENTSOE;
-
 model TestCase1 "Test Case 1, Section 5.1, focuses on the dynamic behavior of the model for the synchronous generator machine and its AVR"
   extends Modelica.Icons.Example;
-  inner PowerGrids.Electrical.System systemPowerGrids annotation(
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
     Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = 0, QStart = 0, SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0, UStart = 21000, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8) annotation(
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = 0, QStart = 0, SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, UPhaseStart = 0, UStart = 21000, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8) annotation (
     Placement(visible = true, transformation(origin = {-26, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.ReferenceBus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true) annotation(
+  PowerGrids.Electrical.Buses.ReferenceBus NTLV(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true) annotation (
     Placement(visible = true, transformation(origin = {24, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Controls.TurbineGovernors.IEEE_TGOV1 TGOV(R = 0.05, T1 = 0.5, T2 = 3, T3 = 10, VMax = 1) annotation(
+  PowerGrids.Electrical.Controls.TurbineGovernors.IEEE_TGOV1 TGOV(R = 0.05, T1 = 0.5, T2 = 3, T3 = 10, VMax = 1) annotation (
     Placement(visible = true, transformation(origin = {-62, 28}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
-  PowerGrids.Electrical.Controls.ExcitationSystems.IEEE_AC4A AVR(Ka = 200, Ta = 0.05, Tb = 10, Tc = 3, VrMax = 4) annotation(
+  PowerGrids.Electrical.Controls.ExcitationSystems.IEEE_AC4A AVR(Ka = 200, Ta = 0.05, Tb = 10, Tc = 3, VrMax = 4) annotation (
     Placement(visible = true, transformation(origin = {-62, -16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Controls.PowerSystemStabilizers.IEEE_PSS2A PSS(Ks1 = 10, Ks2 = 0.1564, M = 0, N = 0, T1 = 0.25, T2 = 0.03, T3 = 0.15, T4 = 0.015, T7 = 2, T8 = 0.5, T9 = 0.1, Tw1 = 2, Tw2 = 2, Tw3 = 2, Tw4 = 0, VstMax = 0.1, VstMin = -0.1) annotation(
+  PowerGrids.Electrical.Controls.PowerSystemStabilizers.IEEE_PSS2A PSS(Ks1 = 10, Ks2 = 0.1564, M = 0, N = 0, T1 = 0.25, T2 = 0.03, T3 = 0.15, T4 = 0.015, T7 = 2, T8 = 0.5, T9 = 0.1, Tw1 = 2, Tw2 = 2, Tw3 = 2, Tw4 = 0, VstMax = 0.1, VstMin = -0.1) annotation (
     Placement(visible = true, transformation(origin = {-98, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression zero annotation(
+  Modelica.Blocks.Sources.RealExpression zero annotation (
     Placement(visible = true, transformation(origin = {-102, -48}, extent = {{-12, -10}, {12, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression VrefPu(y = if time < 0.1 then 1.005 else 1.055) annotation(
+  Modelica.Blocks.Sources.RealExpression VrefPu(y = if time < 0.1 then 1.005 else 1.055) annotation (
     Placement(visible = true, transformation(origin = {-102, -31}, extent = {{-12, -11}, {12, 11}}, rotation = 0)));
-  Modelica.Blocks.Sources.RealExpression RefLPu(y = 0) annotation(
+  Modelica.Blocks.Sources.RealExpression RefLPu(y = 0) annotation (
     Placement(visible = true, transformation(origin = {-98, 24}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
   Types.PerUnit AA_01_GEN_Upu = GEN.port.VPu "Fig. 5.1, terminal voltage";
   Types.PerUnit AA_02_GEN_efd = GEN.ufPuIn "Fig. 5.2, excitation voltage";
-  
+
 
 equation
-  connect(GEN.PPu, PSS.Vsi2Pu) annotation(
-    Line(points = {{-16, -2}, {0, -2}, {0, 56}, {-130, 56}, {-130, -6}, {-108, -6}, {-108, -6}}, color = {0, 0, 127}));
-  connect(GEN.VPu, AVR.VcPu) annotation(
+  connect(GEN.PPu, PSS.Vsi2Pu) annotation (
+    Line(points={{-16,-2},{0,-2},{0,56},{-130,56},{-130,-6},{-108.2,-6},{-108.2,
+          -6}},                                                                                  color = {0, 0, 127}));
+  connect(GEN.VPu, AVR.VcPu) annotation (
     Line(points = {{-16, -6}, {10, -6}, {10, 66}, {-138, 66}, {-138, -14}, {-72, -14}, {-72, -14}}, color = {0, 0, 127}));
-  connect(RefLPu.y, TGOV.RefLPu) annotation(
+  connect(RefLPu.y, TGOV.RefLPu) annotation (
     Line(points = {{-87, 24}, {-72, 24}}, color = {0, 0, 127}));
-  connect(VrefPu.y, AVR.VrefPu) annotation(
-    Line(points = {{-88.8, -31}, {-89.3, -31}, {-89.3, -31}, {-85.8, -31}, {-85.8, -18}, {-79.8, -18}, {-79.8, -18}, {-71.8, -18}}, color = {0, 0, 127}));
-  connect(zero.y, AVR.VuelPu) annotation(
-    Line(points = {{-88.8, -48}, {-79.8, -48}, {-79.8, -22}, {-71.8, -22}}, color = {0, 0, 127}));
-  connect(GEN.omegaPu, PSS.Vsi1Pu) annotation(
+  connect(VrefPu.y, AVR.VrefPu) annotation (
+    Line(points={{-88.8,-31},{-89.3,-31},{-89.3,-31},{-85.8,-31},{-85.8,-18},{
+          -79.8,-18},{-79.8,-18},{-72,-18}},                                                                                        color = {0, 0, 127}));
+  connect(zero.y, AVR.VuelPu) annotation (
+    Line(points={{-88.8,-48},{-79.8,-48},{-79.8,-22},{-72,-22}},            color = {0, 0, 127}));
+  connect(GEN.omegaPu, PSS.Vsi1Pu) annotation (
     Line(points = {{-16, 2}, {-8, 2}, {-8, 48}, {-124, 48}, {-124, 6}, {-108, 6}}, color = {0, 0, 127}));
-  connect(PSS.VstPu, AVR.VsPu) annotation(
+  connect(PSS.VstPu, AVR.VsPu) annotation (
     Line(points = {{-87, 0}, {-76.5, 0}, {-76.5, -10}, {-72, -10}}, color = {0, 0, 127}));
-  connect(AVR.efdPu, GEN.ufPuIn) annotation(
-    Line(points = {{-51, -16}, {-48.5, -16}, {-48.5, -16}, {-44, -16}, {-44, -4}, {-41, -4}, {-41, -4}, {-36, -4}}, color = {0, 0, 127}));
-  connect(GEN.omegaPu, TGOV.omegaPu) annotation(
+  connect(AVR.efdPu, GEN.ufPuIn) annotation (
+    Line(points={{-50.4,-16},{-48.5,-16},{-48.5,-16},{-44,-16},{-44,-4},{-41,-4},
+          {-41,-4},{-36,-4}},                                                                                       color = {0, 0, 127}));
+  connect(GEN.omegaPu, TGOV.omegaPu) annotation (
     Line(points = {{-16, 2}, {-8, 2}, {-8, 48}, {-84, 48}, {-84, 32}, {-72, 32}}, color = {0, 0, 127}));
-  connect(TGOV.PMechPu, GEN.PmPu) annotation(
+  connect(TGOV.PMechPu, GEN.PmPu) annotation (
     Line(points = {{-52, 28}, {-44, 28}, {-44, 4}, {-40, 4}, {-40, 4}, {-36, 4}}, color = {0, 0, 127}));
-  connect(GEN.terminal, NTLV.terminal) annotation(
+  connect(GEN.terminal, NTLV.terminal) annotation (
     Line(points = {{-26, 0}, {-26, -10}, {-26, -10}, {-26, -20}, {-2, -20}, {-2, -20}, {24, -20}}));
-  annotation(
+  annotation (
     Diagram(coordinateSystem(extent = {{-180, -100}, {180, 100}})),
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",


### PR DESCRIPTION
The IEEE AC4A excitation system model contains a block named "HV GATE". This model has the following meaning (from Annex A of the IEEE 412.3-2005):
"Model block with two inputs and one output, the output always corresponding to the higher of the two inputs."
This block was implemented in PowerGrids using a VaribleLimiter and using the trick to set the larger variable limit to 1e9.
If, instead, one uses the builtin MSL block "max", one sticks with the IEEE descriptions and avoids setting the arbitrary value 1e9 as a "largeReal".
This is what this ticket does, in addition to enhancing the visual appearance of this model diagram.
So, it substitutes the block "variableLimiter" with "max".
