### PR TITLE
Fixed inputs in PortAC

### DIFF
--- a/PowerGrids/Electrical/BaseClasses/PortAC.mo
+++ b/PowerGrids/Electrical/BaseClasses/PortAC.mo
@@ -27,10 +27,13 @@ model PortAC "AC port computing auxiliary quantities"
   final parameter Types.ComplexCurrent iStart = CM.conj(Complex(PStart,QStart)/(Complex(3)*vStart))
     "Start value of current phasor flowing into the port";
   
-  input Types.ComplexVoltage v(re(nominal = VBase, start = vStart.re),
-                               im(nominal = VBase, start = vStart.im)) "Port voltage (line-to-neutral)";
-  input Types.ComplexCurrent i(re(nominal = IBase, start = iStart.re),
-                               im(nominal = IBase, start = iStart.im)) "Port current";
+  connector InputComplexVoltage = input Types.ComplexVoltage "Marks potential input for balancedness check without requiring binding equation";
+  connector InputComplexCurrent = input Types.ComplexCurrent "Marks potential input for balancedness check without requiring binding equation";
+
+  InputComplexVoltage v(re(nominal = VBase, start = vStart.re),
+                        im(nominal = VBase, start = vStart.im)) "Port voltage (line-to-neutral)";
+  InputComplexCurrent i(re(nominal = IBase, start = iStart.re),
+                        im(nominal = IBase, start = iStart.im)) "Port current";
 
   Types.ComplexVoltage u(re(nominal = UBase, start = vStart.re*sqrt(3)),
                          im(nominal = UBase, start = vStart.im*sqrt(3))) = sqrt(3)*v


### PR DESCRIPTION
The PortAC model had two complex inputs `v` and `i`. They were marked as inputs to make the model balanced, since enough equations are expected to be given to determine their values.

However, [Section 4.4.2.2](https://specification.modelica.org/v3.4/Ch4.html#prefix-rules) of the Modelica Specification mandates that _In component models and blocks, the input prefix defines that a binding equation has to be provided for the corresponding variable when the component is utilized in order to guarantee a locally balanced model_. The relationship between the port current and voltage and the connector current and voltage in OnePortAC and TwoPortAC are complex and depend on the initialization mode, hence simple binding equations cannot be used.

In fact, the models still work, but if a Modelica tool (e.g. Dymola) tries to verify the local balancing of components, it will complain about input variables lacking binding equations.

This PR then introduces the correct way to handle this situation, i.e., connector inputs.

This is explained in the Modelica Specification [Section 4.7](https://specification.modelica.org/v3.4/Ch4.html#balanced-models):  _The variables are marked as input to get correct equation count. Since they are connectors they should neither be given binding equations in derived classes nor when using the model. The design pattern is to give textual equations for them (as below); using connect-equations for these connectors would be possible (and would work) but is not part of the design_.