### PR TITLE
Add IfPu as generator outputs; enhance generator icon

### DIFF
--- a/PowerGrids/Electrical/Machines/SynchronousMachine4WindingsInternalParameters.mo
+++ b/PowerGrids/Electrical/Machines/SynchronousMachine4WindingsInternalParameters.mo
@@ -1,5 +1,4 @@
 within PowerGrids.Electrical.Machines;
-
 model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 windings - internal parameters"
   extends BaseClasses.OnePortACdqPU(
     final generatorConvention = true,
@@ -27,7 +26,7 @@ model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 
   parameter Types.PerUnit rQ2Pu "Resistance of quadrature axis 2nd damper in p.u.";
   parameter Types.PerUnit DPu = 0 "Damping coefficient of the swing equation in p.u.";
   parameter Modelica.SIunits.Time H "Kinetic constant = kinetic energy / rated power";
-  parameter Types.Choices.ExcitationPuType excitationPuType = 
+  parameter Types.Choices.ExcitationPuType excitationPuType=
     PowerGrids.Types.Choices.ExcitationPuType.nominalStatorVoltageNoLoad "Choice of excitation base voltage";
   parameter Boolean neglectTransformerTerms = true "Neglect the transformer terms in the Park equations";
   parameter Boolean referenceGenerator = false "True if reference generator in an isolated synchronous system";
@@ -42,16 +41,17 @@ model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 
   final parameter Types.PerUnit ufPuInStart(fixed = false) "Start value of input exciter voltage in p.u. (user-selcted base";
   final parameter Types.PerUnit ifPuStart(fixed = false) "Start value of ifPu";
   // Input variables
-  Modelica.Blocks.Interfaces.RealInput PmPu(unit = "1") "Input mechanical power in p.u. (base PNom)" annotation(
-    Placement(visible = true, transformation(origin = {-106, 46}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealInput ufPuIn(unit = "1", start = ufPuInStart) "Input voltage of exciter winding in p.u. (user-selected base voltage)" annotation(
-    Placement(visible = true, transformation(origin = {-104, -50}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput PmPu(unit = "1") "Input mechanical power in p.u. (base PNom)" annotation (
+    Placement(visible = true, transformation(origin = {-106, 46}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin={-100,40},    extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput ufPuIn(unit = "1", start = ufPuInStart) "Input voltage of exciter winding in p.u. (user-selected base voltage)" annotation (
+    Placement(visible = true, transformation(origin = {-104, -50}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin={-102,-40},    extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   // Output variables
-  Modelica.Blocks.Interfaces.RealOutput omega(unit = "rad/s") "Angular frequency in rad/s for system object" annotation(
-    Placement(visible = true, transformation(origin = {106, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {101, 59}, extent = {{-11, -11}, {11, 11}}, rotation = 0)));        
-// Other per-unit variables
-  Modelica.Blocks.Interfaces.RealOutput omegaPu(start = 1) "Angular frequency in p.u." annotation(
-    Placement(visible = true, transformation(origin = {106, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput omega(unit = "rad/s")
+    "Angular frequency in rad/s for system object"                                                           annotation (
+    Placement(visible = true, transformation(origin = {106, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin={101,79},    extent = {{-11, -11}, {11, 11}}, rotation = 0)));
+    // Other per-unit variables
+  Modelica.Blocks.Interfaces.RealOutput omegaPu(start = 1) "Angular frequency in p.u." annotation (
+    Placement(visible = true, transformation(origin = {106, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin={100,40},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Types.PerUnit iDPu(start = 0) "Current of direct axis damper in p.u";
   Types.PerUnit ifPu(start = ifPuStart) "Current of excitation winding in p.u.";
   Types.PerUnit iQ1Pu(start = 0) "Current of quadrature axis 1st damper in p.u.";
@@ -69,33 +69,43 @@ model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 
   Types.PerUnit PePu(start = -PStart/SNom) "Electrical power in p.u. (base SNom)";
   Types.PerUnit PePuPNom = PePu*SNom/PNom "Electrical active power in p.u. (base PNom)";
 
-  // SI-unit variables
+// SI-unit variables
   Types.Frequency f = systemPowerGrids.fNom*omegaPu "Frequency of rotation of d-q axes";
-  Modelica.Blocks.Interfaces.RealOutput VPu "Port voltage magnitude [pu]" annotation(
-    Placement(visible = true, transformation(origin = {106, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealOutput PPu "Active Power Production [pu base PNom]" annotation(
-    Placement(visible = true, transformation(origin = {106, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput VPu "Port voltage magnitude [pu]" annotation (
+    Placement(visible = true, transformation(origin={106,20},   extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin={100,-40},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput PPu "Active Power Production [pu base PNom]" annotation (
+    Placement(visible = true, transformation(origin={106,40},    extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin={100,0},      extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput IfPu=ifPu "Field current in p.u."
+    annotation (Placement(
+      visible=true,
+      transformation(
+        origin={106,0},
+        extent={{-10,-10},{10,10}},
+        rotation=0),
+      iconTransformation(
+        origin={101,-81},
+        extent={{-11,-11},{11,11}},
+        rotation=0)));
 initial equation
-  // Scaling factor for excitation p.u. voltage
+// Scaling factor for excitation p.u. voltage
   if excitationPuType == Types.Choices.ExcitationPuType.Kundur then
     kuf = 1 "Choice of per-unit as per Kundur textbook";
   else
     kuf = rfPu / MdPu "Base voltage gives 1 p.u. air-gap stator voltage at no load";
   end if;
-  // Equations to compute start values
-  // these equations are the same that involve the actual variables in the equation section
-  // except that they involve the start values instead, and they do not contain terms which
-  // are zero at steady state (e.g., all the damping winding currents)
-  // the Modelica tool figures out automatically how to solve them for the unknown parameters
-  udPuStart = raPu*idPuStart - omegaNomPu*lambdaqPuStart;
+// Equations to compute start values
+// these equations are the same that involve the actual variables in the equation section
+// except that they involve the start values instead, and they do not contain terms which
+// are zero at steady state (e.g., all the damping winding currents)
+// the Modelica tool figures out automatically how to solve them for the unknown parameters
+  udPuStart = raPu * idPuStart - omegaNomPu * lambdaqPuStart;
   uqPuStart = raPu*iqPuStart + omegaNomPu*lambdadPuStart;
   lambdadPuStart = (MdPu + LdPu)*idPuStart + MdPu*ifPuStart;
   ufPuStart =  rfPu*ifPuStart;
   ufPuInStart = ufPuStart/kuf;
-
-  // Equations to determine the initial state values
+// Equations to determine the initial state values
   if initOpt == InitializationOption.noInit then
-    // No initial equations
+// No initial equations
   else
     omegaPu = omegaNomPu;
     der(omega) = 0;
@@ -109,42 +119,38 @@ initial equation
     der(lambdaQ2Pu) = 0;
   end if;
 equation
-  // Flux linkages
+// Flux linkages
   lambdadPu = (MdPu + LdPu) * idPu + MdPu * ifPu + MdPu * iDPu;
   lambdafPu =     MdPu      *idPu + (MdPu + LfPu + mrcPu)*ifPu +    (MdPu + mrcPu)    *iDPu;
   lambdaDPu =     MdPu      *idPu +     (MdPu + mrcPu)   *ifPu + (MdPu + LDPu + mrcPu)*iDPu;
   lambdaqPu = (MqPu + LqPu) *iqPu +         MqPu         *iQ1Pu +        MqPu         *iQ2Pu;
-  lambdaQ1Pu =     MqPu     *iqPu +     (MqPu + LQ1Pu )  *iQ1Pu +        MqPu         *iQ2Pu;
+  lambdaQ1Pu =     MqPu     *iqPu +     (MqPu + LQ1Pu)   *iQ1Pu +        MqPu         *iQ2Pu;
   lambdaQ2Pu =     MqPu     *iqPu +         MqPu         *iQ1Pu +    (MqPu + LQ2Pu)   *iQ2Pu;
-
-  // Equivalent circuit equations in Park's coordinates
+// Equivalent circuit equations in Park's coordinates
   if neglectTransformerTerms then
     udPu = raPu * idPu - omegaPu * lambdaqPu;
     uqPu = raPu * iqPu + omegaPu * lambdadPu;
   else
     udPu = raPu * idPu - omegaPu * lambdaqPu + der(lambdadPu) / omegaBase;
     uqPu = raPu * iqPu + omegaPu * lambdadPu + der(lambdaqPu) / omegaBase;
-  end if;  
+  end if;
   ufPu =  rfPu *ifPu  + der(lambdafPu)/omegaBase;
   0    =  rDPu *iDPu  + der(lambdaDPu)/omegaBase;
   0    =  rQ1Pu*iQ1Pu + der(lambdaQ1Pu)/omegaBase;
   0    =  rQ2Pu*iQ2Pu + der(lambdaQ2Pu)/omegaBase;
-
-  // Mechanical equations
+// Mechanical equations
   der(theta) = (omegaPu - omegaRefPu) * omegaBase;
   2*H*der(omegaPu) = (CmPu*PNom/SNom - CePu) - DPu*(omegaPu - omegaRefPu);
   CePu = lambdaqPu*idPu - lambdadPu*iqPu;
   PePu = CePu*omegaPu;
   PmPu = CmPu*omegaPu;
   omega = omegaPu*omegaBase;
-
-  // Excitation voltage p.u. conversion
+// Excitation voltage p.u. conversion
   ufPu = ufPuIn * kuf;
-
-  // Output signal equations
+// Output signal equations
   VPu = port.VPu;
   PPu = -port.P/PNom;
-annotation(
+annotation (
     Documentation(info = "<html><head></head><body><p>Model of a sychronous machine with four windings. The transformer voltage terms are neglected if <code>neglectTransformerTerms=true</code>. The model parameters refer directly to internal physical parameters such as inductances and resistances.</p>
 <p>The model is taken from the theory manual of the Eurostag software. For consistency with the base class <a href=\"modelica://PowerGrids.Electrical.BaseClasses.OnePortACdq\">OnePortACdq</a>, however, the currents ifPu, idPu and iqPu are all assumed to be positive entering, while the Eurostag manual assumes them to be all positive leaving. Therefore, all the current and fluxes have an opposite sign in the Park equations.</p>
 <p>This model is in fact equivalent to the model described in Kundur, Power Systems Stability and Control, Chapter 3, except for the current sign conventions, which in that case are assumed to be positive entering for the rotor winding and positive leaving for the direct and quadrature stator axes. The correspondance of the parameter symbols is given in the table, all parameters are in p.u. referred to the machine rated values.</p>
@@ -169,5 +175,12 @@ annotation(
 <li><code>Types.ExcitationPuType.nominalStatorVoltageNoLoad</code>: 1 p.u. of excitation voltage gives 1 p.u. of air-gap stator voltage at no-load conditions</li>
 <li><code>Types.ExcitationPuType.Kundur</code>: base voltage as in Kundur, Power Systems Stability and Control, Chapter 3. Note that in this case, typical p.u. values are less than 0.001</li>
 </ul>
-</body></html>"));
+</body></html>"), Icon(graphics={
+        Line(points={{38,46},{90,78}}, color={0,0,0}),
+        Line(points={{54,26},{90,38}}, color={0,0,0}),
+        Line(points={{60,0},{90,0},{92,0}}, color={0,0,0}),
+        Line(points={{36,-48},{90,-82}}, color={0,0,0}),
+        Line(points={{-82,40},{-52,30}}, color={0,0,0}),
+        Line(points={{-82,-40},{-54,-26}}, color={0,0,0}),
+        Line(points={{54,-26},{90,-40}}, color={0,0,0})}));
 end SynchronousMachine4WindingsInternalParameters;


### PR DESCRIPTION
The PowerGrids Synchronous machine model computes internally ifPu, but does not output it, since  it is not needed in all the existing PowerGrids examples. 
In particular, the PowerGrids voltage regulator IEEE_AC4A is a special implementation of the original IEEE AC4A regulator, which does not make usage of If.
The original IEEE AC4A. however,  needs I_FD as a dynamic limit, and also other IEEE regulators need this quantity.

To allow users to use regulators that need I_f, this current should be outputted. In the proposed implementation the output name chosen is "IfPu" since it follows the pattern of the already existing machine output VfPu.
The proposed change has no effect on any of the PowerGrids models.

Moreover, the icon of generators has been slightly changed, to comply with the common non-written rule of Modelica icons implicitly stating that connectors should have connections to some other icon element or at least be very near to them. 
I could not find any MSL library braking this rule: either the connectors touch a square container (as for Blocks), or other shapes defining the model shape (e.g. electrical machines), or are very near to other icon elements (e.g. Mechanical.Rotational.Sources.Torque).

Unfortunately this PR contains also removal of white spaces (e.g. conversion of  `origin = {-100, 40},`  into `origin={-100,40},>.` These changes are made automatically by dymola, and reduce readability of diffs between the original and modified version of the model.