### PR TITLE
Added encapsulated prefix to local enumeration definition

### DIFF
--- a/PowerGrids/Controls/LimiterWithLag.mo
+++ b/PowerGrids/Controls/LimiterWithLag.mo
@@ -2,7 +2,7 @@ within PowerGrids.Controls;
 block LimiterWithLag
   extends Modelica.Blocks.Interfaces.SISO;
   
-  type State = enumeration(
+  encapsulated type State = enumeration(
     upperSat "Upper limit reached",
     lowerSat "Lower limit reached",
     notSat   "u is in range"

--- a/PowerGrids/Electrical/Branches/BaseClasses/TapChangerPhaseShifterCommon.mo
+++ b/PowerGrids/Electrical/Branches/BaseClasses/TapChangerPhaseShifterCommon.mo
@@ -4,8 +4,8 @@ partial model TapChangerPhaseShifterCommon "Common base class for tap-changer/ph
   extends Icons.Transformer;
 
   final constant Real NotUsed = Modelica.Constants.inf "Generic default value for not-used parameters";
-  type MonitoredQuantitySelection = enumeration(currentMagnitude "phase shifter monitors the port_b current magnitude",
-                                                activePower "phase shifter monitors the port_b active power");
+  encapsulated type MonitoredQuantitySelection = enumeration(currentMagnitude "phase shifter monitors the port_b current magnitude",
+                                                             activePower "phase shifter monitors the port_b active power");
 
   parameter Types.Resistance R = 0 "Series resistance";
   parameter Types.Reactance X = 0 "Series reactance";

--- a/PowerGrids/Electrical/Branches/BaseClasses/TapChangerPhaseShifterLogicCommon.mo
+++ b/PowerGrids/Electrical/Branches/BaseClasses/TapChangerPhaseShifterLogicCommon.mo
@@ -2,18 +2,18 @@ within PowerGrids.Electrical.Branches.BaseClasses;
 partial model TapChangerPhaseShifterLogicCommon
   final constant Types.Time timeInfinity = Modelica.Constants.inf "Default value for counters";
   
-  type State = enumeration (moveDownN "1: tap-changer/phase-shifter has decreased the next tap", 
-                            moveDown1 "2: tap-changer/phase-shifter has decreased the first tap", 
-                            waitingToMoveDown "3: tap-changer/phase-shifter is waiting to decrease the first tap", 
-                            standard "4:tap-changer/phase-shifter is in standard state with UThresholdDown <= UMonitored <= UThresholdUp", 
-                            waitingToMoveUp "5: tap-changer/phase-shifter is waiting to increase the first tap", 
-                            moveUp1 "6: tap-changer/phase-shifter has increased the first tap", 
-                            moveUpN "7: tap-changer/phase-shifter has increased the next tap",
-                            locked "8: tap-changer/phase-shifter locked");
+  encapsulated type State = enumeration (moveDownN "1: tap-changer/phase-shifter has decreased the next tap",
+                                         moveDown1 "2: tap-changer/phase-shifter has decreased the first tap",
+                                         waitingToMoveDown "3: tap-changer/phase-shifter is waiting to decrease the first tap",
+                                         standard "4:tap-changer/phase-shifter is in standard state with UThresholdDown <= UMonitored <= UThresholdUp",
+                                         waitingToMoveUp "5: tap-changer/phase-shifter is waiting to increase the first tap",
+                                         moveUp1 "6: tap-changer/phase-shifter has increased the first tap",
+                                         moveUpN "7: tap-changer/phase-shifter has increased the next tap",
+                                         locked "8: tap-changer/phase-shifter locked");
   State state(start = stateStart, fixed = true);
   
-  type ActionType = enumeration (direct "Whether increasing the tap will increase the monitored value",
-                                 reverse "Whether increasing the tap will decrease the monitored value");
+  encapsulated type ActionType = enumeration (direct "Whether increasing the tap will increase the monitored value",
+                                              reverse "Whether increasing the tap will decrease the monitored value");
   
   parameter Types.Time t1st(min = 0) "Time lag before changing the first tap";
   parameter Types.Time tNext(min = 0) "Time lag before changing subsequent taps";

--- a/PowerGrids/Electrical/Branches/LineConstantImpedanceWithBreakers.mo
+++ b/PowerGrids/Electrical/Branches/LineConstantImpedanceWithBreakers.mo
@@ -3,7 +3,7 @@ within PowerGrids.Electrical.Branches;
 model LineConstantImpedanceWithBreakers "Transmission line with constant impedance and breakers"
   extends BaseClasses.PiNetwork(final UNomA = UNom, final UNomB = UNom);
   extends Icons.Line;
-  type BreakersState = enumeration(
+  encapsulated type BreakersState = enumeration(
     AcBc "Both breakers at port A and at port B closed", 
     AcBo "Breaker at port A closed, breaker at port B open", 
     AoBc "Breaker at port A open, breaker at port B closed", 

--- a/PowerGrids/Electrical/Branches/TransformerFixedRatioWithBreaker.mo
+++ b/PowerGrids/Electrical/Branches/TransformerFixedRatioWithBreaker.mo
@@ -3,7 +3,7 @@ model TransformerFixedRatioWithBreaker
   extends BaseClasses.PiNetwork;
   extends Icons.Transformer;
 
-  type BreakersState = enumeration(
+  encapsulated type BreakersState = enumeration(
     Bc "breaker closed",
     Bo "breaker open");
   parameter Boolean useBreaker = false "Use breaker (port b)" annotation(


### PR DESCRIPTION
According to Section 5.3.2.

This makes sure the lookup rules are fully respected, and avoids warnings (or errors in pedantic mode) when checking with Dymola
