### PR TITLE
Removed final modifier on UNomA, UNomB in line models

### DIFF
--- a/PowerGrids/Electrical/Branches/LineConstantImpedance.mo
+++ b/PowerGrids/Electrical/Branches/LineConstantImpedance.mo
@@ -1,8 +1,8 @@
 within PowerGrids.Electrical.Branches;
 model LineConstantImpedance "Transmission line with constant impedance"
   extends BaseClasses.PiNetwork(
-    final UNomA = UNom,
-    final UNomB = UNom);
+    UNomA = UNom,
+    UNomB = UNomA);
   extends Icons.Line;
 
   parameter Types.Voltage UNom(start = 400e3) "Nominal/rated voltage";

--- a/PowerGrids/Electrical/Branches/LineConstantImpedanceFault.mo
+++ b/PowerGrids/Electrical/Branches/LineConstantImpedanceFault.mo
@@ -1,8 +1,8 @@
 within PowerGrids.Electrical.Branches;
 model LineConstantImpedanceFault "Transmission line with constant impedance and fault in intermediate position"
   extends Electrical.BaseClasses.TwoPortAC(
-    final UNomA = UNom,
-    final UNomB = UNom);
+    UNomA = UNom,
+    UNomB = UNomA);
   extends Icons.Line;
 
   parameter Types.Voltage UNom(start = 400e3) "Nominal/rated voltage";

--- a/PowerGrids/Electrical/Branches/LineConstantImpedanceWithBreakers.mo
+++ b/PowerGrids/Electrical/Branches/LineConstantImpedanceWithBreakers.mo
@@ -1,7 +1,7 @@
 within PowerGrids.Electrical.Branches;
 
 model LineConstantImpedanceWithBreakers "Transmission line with constant impedance and breakers"
-  extends BaseClasses.PiNetwork(final UNomA = UNom, final UNomB = UNom);
+  extends BaseClasses.PiNetwork(UNomA = UNom, UNomB = UNomA);
   extends Icons.Line;
   encapsulated type BreakersState = enumeration(
     AcBc "Both breakers at port A and at port B closed", 


### PR DESCRIPTION
I think we made a mistake when we define a single `UNom` parameter for the line models and made `UNomA `and `UNomB `final, because that changes the interface compared to the TwoPortAC base class. It would have been much better to just make `UNomB = UNomA` by default, so that one could simply give one value instead of two.

Now we can't change the interface of the line models, othewise we'd break all existing models. However, we can remove the final modifiers on UNomA and UNomB, so that they can still be changed according to the TwoPortAC base class.

This change is fully backwards compatible.