### PR TITLE
Models and examples of a first order asynchronous machine

### DIFF
--- a/PowerGrids/Electrical/Machines/AsynchronousMachine1stOrderNoSlipStart.mo
+++ b/PowerGrids/Electrical/Machines/AsynchronousMachine1stOrderNoSlipStart.mo
@@ -1,0 +1,38 @@
+within PowerGrids.Electrical.Machines;
+
+model AsynchronousMachine1stOrderNoSlipStart
+  import PowerGrids.Types.Choices.LocalInitializationOption;
+  extends Icons.Machine;
+  extends BaseClasses.OnePortAC(portVariablesPu = true,
+  localInit = LocalInitializationOption.PQ); 
+  
+  parameter Types.Choices.InitializationOption initOpt = systemPowerGrids.initOpt "Initialization option";
+  parameter Types.PerUnit RsPu "Stator resistance in p.u.";
+  parameter Types.PerUnit XsPu "Stator reactance  in p.u.";
+  parameter Types.PerUnit RrPu "Rotor resistance  in p.u.";
+  parameter Types.PerUnit XrPu "Rotor reactance  in p.u.";
+  parameter Types.PerUnit XmPu "Magnetization reactance  in p.u.";
+  parameter Modelica.SIunits.Time H "Kinetic constant = kinetic energy / rated power";
+  final parameter Types.PerUnit CePuStart(fixed=false);
+  
+  Types.PerUnit omegaRefPu = systemPowerGrids.omegaRef/systemPowerGrids.omegaNom "Reference frequency in p.u.";
+  Types.PerUnit omegaPu "Angular frequency in p.u.";
+  Types.PerUnit CePu(start=CePuStart) "Electrical torque in p.u. (base SNom/omegaBase)";
+  Types.PerUnit CmPu "Mechanical torque in p.u. (base PNom/omegaBase)";
+  Types.PerUnit slipPu;
+  Types.ComplexPerUnit ZsrPu = Complex(RsPu + RrPu / slipPu, XsPu + XrPu) "Sum of stator and rotor impedance";
+  Types.ComplexPerUnit ZmPu  = Complex(0, XmPu) "Magetization impedance";
+initial equation
+  der(slipPu) = 0;
+  CePuStart = (port.UStart/port.UNom)^2*RrPu/slipPu/CM.'abs'(ZsrPu)^2;
+  CmPu = CePuStart;
+equation
+  // Mechanical equations
+  der(CmPu) = 0; // Temporary load torque changes disabled
+  slipPu = omegaRefPu - omegaPu;
+  der(omegaPu) = -1 / (2 * H) * (CmPu - CePu);
+  // Equivalent circuit equations
+  CePu = port.VPu^2*RrPu/slipPu/CM.'abs'(ZsrPu)^2;
+  port.iPu = port.vPu / ZsrPu + port.vPu / ZmPu;
+   
+end AsynchronousMachine1stOrderNoSlipStart;

--- a/PowerGrids/Electrical/Machines/AsynchronousMachine1stOrderWithSlipStart.mo
+++ b/PowerGrids/Electrical/Machines/AsynchronousMachine1stOrderWithSlipStart.mo
@@ -1,0 +1,38 @@
+within PowerGrids.Electrical.Machines;
+
+model AsynchronousMachine1stOrderWithSlipStart
+  import PowerGrids.Types.Choices.LocalInitializationOption;
+  extends Icons.Machine; 
+  extends BaseClasses.OnePortAC(portVariablesPu = true,
+  localInit = LocalInitializationOption.PQ);
+
+  parameter Types.PerUnit RsPu "Stator resistance in p.u.";
+  parameter Types.PerUnit XsPu "Stator reactance  in p.u.";
+  parameter Types.PerUnit RrPu "Rotor resistance  in p.u.";
+  parameter Types.PerUnit XrPu "Rotor reactance  in p.u.";
+  parameter Types.PerUnit XmPu "Magnetization reactance  in p.u.";
+  parameter Modelica.SIunits.Time H "Kinetic constant = kinetic energy / rated power";
+
+  final parameter Types.PerUnit CePuStart(fixed=false);
+  parameter Types.PerUnit slipPuStart "Start value of phase-to-phase voltage phasor, phase angle"
+    annotation(Dialog(tab = "Initialization"));
+  Types.PerUnit omegaRefPu = systemPowerGrids.omegaRef/systemPowerGrids.omegaNom "Reference frequency in p.u.";
+  Types.PerUnit omegaPu "Angular frequency in p.u.";
+  Types.PerUnit CePu(start=CePuStart) "Electrical torque in p.u. (base SNom/omegaBase)";
+  Types.PerUnit CmPu "Mechanical torque in p.u. (base PNom/omegaBase)";
+  Types.PerUnit slipPu(start=slipPuStart, fixed=true) "Machine slip";
+  Types.ComplexPerUnit ZsrPu = Complex(RsPu + RrPu / slipPu, XsPu + XrPu) "Sum of stator and rotor impedance";
+  Types.ComplexPerUnit ZmPu  = Complex(0, XmPu) "Magetization impedance";
+initial equation
+  CePuStart = (port.UStart/port.UNom)^2*RrPu/slipPuStart/CM.'abs'(ZsrPu)^2;
+  CmPu = CePuStart;
+equation
+  // Mechanical equations
+  der(CmPu) = 0; // Temporary load torque changes disabled
+  slipPu = omegaRefPu - omegaPu;
+  der(omegaPu) = -1 / (2 * H) * (CmPu - CePu);
+  // Equivalent circuit equations
+  CePu = port.VPu^2*RrPu/slipPu/CM.'abs'(ZsrPu)^2;
+  port.iPu = port.vPu / ZsrPu + port.vPu / ZmPu;
+   
+end AsynchronousMachine1stOrderWithSlipStart;

--- a/PowerGrids/Electrical/Machines/package.order
+++ b/PowerGrids/Electrical/Machines/package.order
@@ -1,2 +1,4 @@
 SynchronousMachine4Windings
 SynchronousMachine4WindingsInternalParameters
+AsynchronousMachine1stOrderNoSlipStart
+AsynchronousMachine1stOrderWithSlipStart

--- a/PowerGrids/Electrical/PowerFlow/AMBus.mo
+++ b/PowerGrids/Electrical/PowerFlow/AMBus.mo
@@ -1,0 +1,23 @@
+within PowerGrids.Electrical.PowerFlow;
+
+model AMBus
+  extends BaseClasses.OnePortAC(portVariablesPu = true);
+  extends Icons.Machine;
+
+  parameter Types.ActivePower P = SNom "Active power entering the bus";
+  parameter Types.PerUnit Rs "Stator resistance";
+  parameter Types.PerUnit Xs "Stator reactance";
+  parameter Types.PerUnit Rr "Rotor resistance";
+  parameter Types.PerUnit Xr "Rotor reactance";
+  parameter Types.PerUnit Xm "Magnetization reactance";
+  Types.PerUnit slip "Machine slip in p.u.";
+
+equation
+// Active Power is considered to be independent of voltage variations
+// and thus kept constant during power flow iterations
+  port.P = P;
+// A steady state circuit of the asynchronous machine
+  port.iPu = port.vPu / Complex(Rs + Rr / slip, Xs + Xr) + port.vPu / Complex(0, Xm);
+  annotation(
+    Icon(graphics = {Text(origin = {84, 10}, extent = {{-20, 20}, {40, -40}}, textString = "AM")}));
+end AMBus;

--- a/PowerGrids/Electrical/PowerFlow/package.order
+++ b/PowerGrids/Electrical/PowerFlow/package.order
@@ -2,4 +2,5 @@ SlackBus
 PVBus
 PQBus
 ZLoad
+AMBus
 Test

--- a/PowerGrids/Examples/AsynchMachine/AM1stOrder.mo
+++ b/PowerGrids/Examples/AsynchMachine/AM1stOrder.mo
@@ -1,0 +1,16 @@
+within PowerGrids.Examples.AsynchMachine;
+
+model AM1stOrder
+  extends Modelica.Icons.Example;
+  inner PowerGrids.Electrical.System systemPowerGrids(initOpt = PowerGrids.Types.Choices.InitializationOption.localSteadyStateFixedPowerFlow) annotation(
+    Placement(visible = true, transformation(origin = {50, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.AsynchronousMachine1stOrderNoSlipStart am1(H = 2, PStart(displayUnit = "MW") = 100000, QStart(displayUnit = "var") = 43595.04412101686, RrPu = 0.00489, RsPu = 0.028, SNom(displayUnit = "V.A") = 0.1e6, UNom(displayUnit = "V") = 20000, UStart(displayUnit = "kV") = 20000, XmPu = 4.236, XrPu = 0.1822, XsPu = 0.01) annotation(
+    Placement(visible = true, transformation(origin = {0, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+Electrical.PowerFlow.SlackBus slack(SNom(displayUnit = "MVA") = 1000000, UNom(displayUnit = "kV") = 20000) annotation(
+    Placement(visible = true, transformation(origin = {0, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(slack.terminal, am1.terminal) annotation(
+    Line(points = {{0, 20}, {0, -30}}));
+  annotation(
+    Documentation(info = "<html><head></head><body>Infinite bus connected to an asynchronous machine.</body></html>"));
+end AM1stOrder;

--- a/PowerGrids/Examples/AsynchMachine/AM1stOrderPowerFlow.mo
+++ b/PowerGrids/Examples/AsynchMachine/AM1stOrderPowerFlow.mo
@@ -1,0 +1,16 @@
+within PowerGrids.Examples.AsynchMachine;
+
+model AM1stOrderPowerFlow
+  extends Modelica.Icons.Example;
+  inner PowerGrids.Electrical.System systemPowerGrids annotation(
+    Placement(visible = true, transformation(origin = {50, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.SlackBus slack(SNom(displayUnit = "MVA") = 1000000, UNom(displayUnit = "kV") = 20000) annotation(
+    Placement(visible = true, transformation(origin = {0, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.AMBus am(P(displayUnit = "MW") = 100000, Rr = 0.00489, Rs = 0.028, SNom(displayUnit = "MVA") = 100000, UNom(displayUnit = "V") = 20000, Xm = 4.236, Xr = 0.1822, Xs = 0.01, portVariablesPhases = true) annotation(
+    Placement(visible = true, transformation(origin = {0, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(am.terminal, slack.terminal) annotation(
+    Line(points = {{0, -20}, {0, 20}}));
+  annotation(
+    Documentation(info = "<html><head></head><body>Power flow for an infinite bus connected to an asynchronous machine.</body></html>"));
+end AM1stOrderPowerFlow;

--- a/PowerGrids/Examples/AsynchMachine/AM1stOrderWithLine.mo
+++ b/PowerGrids/Examples/AsynchMachine/AM1stOrderWithLine.mo
@@ -1,0 +1,24 @@
+within PowerGrids.Examples.AsynchMachine;
+
+model AM1stOrderWithLine
+  extends Modelica.Icons.Example;
+  inner PowerGrids.Electrical.System systemPowerGrids(initOpt = PowerGrids.Types.Choices.InitializationOption.localSteadyStateFixedPowerFlow) annotation(
+    Placement(visible = true, transformation(origin = {50, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.AsynchronousMachine1stOrderNoSlipStart am1(H = 2, PStart(displayUnit = "MW") = 100000, QStart(displayUnit = "MVA") = 43568.36380106667, RrPu = 0.00489, RsPu = 0.028, SNom(displayUnit = "V.A") = 0.1e6, UNom(displayUnit = "V") = 20000, UPhaseStart =-0.04925915594457064, UStart(displayUnit = "kV") = 19424.17645210658, XmPu = 4.236, XrPu = 0.1822, XsPu = 0.01) annotation(
+    Placement(visible = true, transformation(origin = {0, -50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+Electrical.Branches.LineConstantImpedance line(R = 20, SNom(displayUnit = "W") = 1e6, UNom (displayUnit = "V") = 20000, UNomA(displayUnit = "V") = 20e3, X = 200) annotation(
+    Placement(visible = true, transformation(origin = {0, -10}, extent = {{10, -10}, {-10, 10}}, rotation = 90)));
+Electrical.Buses.Bus bus(SNom(displayUnit = "V.A") = 0.1e6, UNom(displayUnit = "V") = 20e3)  annotation(
+    Placement(visible = true, transformation(origin = {0, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+PowerGrids.Electrical.Buses.EquivalentGrid GRID(PStart(displayUnit = "W") = -0.1, QStart = 43568.36380106667,R_X = 1 / 10, SNom (displayUnit = "V.A") = 5e+08, SSC (displayUnit = "V.A") = 2.5e+09, UNom (displayUnit = "V") = 20e3, URef (displayUnit = "V") = 20e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true) annotation(
+    Placement(visible = true, transformation(origin = {0, 16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(bus.terminal, am1.terminal) annotation(
+    Line(points = {{0, -30}, {0, -50}}));
+  connect(line.terminalB, bus.terminal) annotation(
+    Line(points = {{0, -20}, {0, -30}}));
+connect(GRID.terminal, line.terminalA) annotation(
+    Line(points = {{0, 16}, {0, 0}}));
+  annotation(
+    Documentation(info = "<html><head></head><body>Infinite bus connected to an asynchronous machine.</body></html>"));
+end AM1stOrderWithLine;

--- a/PowerGrids/Examples/AsynchMachine/AM1stOrderWithLineAndSlipStart.mo
+++ b/PowerGrids/Examples/AsynchMachine/AM1stOrderWithLineAndSlipStart.mo
@@ -1,0 +1,24 @@
+within PowerGrids.Examples.AsynchMachine;
+
+model AM1stOrderWithLineAndSlipStart
+  extends Modelica.Icons.Example;
+  inner PowerGrids.Electrical.System systemPowerGrids(initOpt = PowerGrids.Types.Choices.InitializationOption.localSteadyStateFixedPowerFlow) annotation(
+    Placement(visible = true, transformation(origin = {50, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.AsynchronousMachine1stOrderWithSlipStart am1(H = 2, PStart(displayUnit = "MW") = 100000, QStart(displayUnit = "MVA") = 43568.36380106667, RrPu = 0.00489, RsPu = 0.028, SNom(displayUnit = "V.A") = 0.1e6, UNom(displayUnit = "V") = 20000, UPhaseStart =-0.04925915594457064, UStart(displayUnit = "kV") = 19424.17645210658, XmPu = 4.236, XrPu = 0.1822, XsPu = 0.01, slipPuStart = 0.00559301) annotation(
+    Placement(visible = true, transformation(origin = {0, -50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+Electrical.Branches.LineConstantImpedance line(R = 20, SNom(displayUnit = "W") = 1e6, UNom (displayUnit = "V") = 20000, UNomA(displayUnit = "V") = 20e3, X = 200) annotation(
+    Placement(visible = true, transformation(origin = {0, -10}, extent = {{10, -10}, {-10, 10}}, rotation = 90)));
+Electrical.Buses.Bus bus(SNom(displayUnit = "V.A") = 0.1e6, UNom(displayUnit = "V") = 20e3)  annotation(
+    Placement(visible = true, transformation(origin = {0, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+PowerGrids.Electrical.Buses.EquivalentGrid GRID(PStart(displayUnit = "W") = -0.1, QStart = 43568.36380106667,R_X = 1 / 10, SNom (displayUnit = "V.A") = 5e+08, SSC (displayUnit = "V.A") = 2.5e+09, UNom (displayUnit = "V") = 20e3, URef (displayUnit = "V") = 20e3, c = 1.1, portVariablesPhases = true, portVariablesPu = true) annotation(
+    Placement(visible = true, transformation(origin = {0, 16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(bus.terminal, am1.terminal) annotation(
+    Line(points = {{0, -30}, {0, -50}}));
+  connect(line.terminalB, bus.terminal) annotation(
+    Line(points = {{0, -20}, {0, -30}}));
+connect(GRID.terminal, line.terminalA) annotation(
+    Line(points = {{0, 16}, {0, 0}}));
+  annotation(
+    Documentation(info = "<html><head></head><body>Infinite bus connected to an asynchronous machine.</body></html>"));
+end AM1stOrderWithLineAndSlipStart;

--- a/PowerGrids/Examples/AsynchMachine/AM1stOrderWithLinePowerFlow.mo
+++ b/PowerGrids/Examples/AsynchMachine/AM1stOrderWithLinePowerFlow.mo
@@ -1,0 +1,24 @@
+within PowerGrids.Examples.AsynchMachine;
+
+model AM1stOrderWithLinePowerFlow
+  extends Modelica.Icons.Example;
+  inner PowerGrids.Electrical.System systemPowerGrids annotation(
+    Placement(visible = true, transformation(origin = {50, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.SlackBus slack(SNom(displayUnit = "MVA") = 1000000, UNom(displayUnit = "kV") = 20000) annotation(
+    Placement(visible = true, transformation(origin = {0, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.AMBus am(P(displayUnit = "MW") = 100000, Rr = 0.00489, Rs = 0.028, SNom(displayUnit = "V.A") = 100000, UNom(displayUnit = "V") = 20000, Xm = 4.236, Xr = 0.1822, Xs = 0.01, portVariablesPhases = true) annotation(
+    Placement(visible = true, transformation(origin = {0, -42}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+PowerGrids.Electrical.Branches.LineConstantImpedance line(R = 20, SNom(displayUnit = "W") = 1e6, UNom(displayUnit = "V") = 20000, UNomA(displayUnit = "V") = 20e3, X = 200) annotation(
+    Placement(visible = true, transformation(origin = {0, -6}, extent = {{10, -10}, {-10, 10}}, rotation = 90)));
+PowerGrids.Electrical.Buses.Bus bus(SNom(displayUnit = "V.A") = 0.1e6, UNom(displayUnit = "V") = 20e3) annotation(
+    Placement(visible = true, transformation(origin = {0, -28}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+connect(line.terminalA, slack.terminal) annotation(
+    Line(points = {{0, 4}, {0, 20}}));
+connect(bus.terminal, am.terminal) annotation(
+    Line(points = {{0, -28}, {0, -42}}));
+connect(line.terminalB, bus.terminal) annotation(
+    Line(points = {{0, -16}, {0, -28}}));
+  annotation(
+    Documentation(info = "<html><head></head><body>Power flow for an infinite bus connected to an asynchronous machine.</body></html>"));
+end AM1stOrderWithLinePowerFlow;

--- a/PowerGrids/Examples/AsynchMachine/AM1stOrderWithSlipStart.mo
+++ b/PowerGrids/Examples/AsynchMachine/AM1stOrderWithSlipStart.mo
@@ -1,0 +1,16 @@
+within PowerGrids.Examples.AsynchMachine;
+
+model AM1stOrderWithSlipStart
+  extends Modelica.Icons.Example;
+  inner PowerGrids.Electrical.System systemPowerGrids(initOpt = PowerGrids.Types.Choices.InitializationOption.localSteadyStateFixedPowerFlow) annotation(
+    Placement(visible = true, transformation(origin = {50, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Machines.AsynchronousMachine1stOrderWithSlipStart am1(H = 2, PStart(displayUnit = "MW") = 100000, QStart(displayUnit = "var") = 43595.04412101686, RrPu = 0.00489, RsPu = 0.028, SNom(displayUnit = "V.A") = 0.1e6, UNom(displayUnit = "V") = 20000, UStart(displayUnit = "kV") = 20000, XmPu = 4.236, XrPu = 0.1822, XsPu = 0.01, slipPuStart = 0.00523788) annotation(
+    Placement(visible = true, transformation(origin = {0, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+Electrical.PowerFlow.SlackBus slack(SNom(displayUnit = "MVA") = 1000000, UNom(displayUnit = "kV") = 20000) annotation(
+    Placement(visible = true, transformation(origin = {0, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(slack.terminal, am1.terminal) annotation(
+    Line(points = {{0, 20}, {0, -30}}));
+  annotation(
+    Documentation(info = "<html><head></head><body>Infinite bus connected to an asynchronous machine.</body></html>"));
+end AM1stOrderWithSlipStart;

--- a/PowerGrids/Examples/AsynchMachine/package.mo
+++ b/PowerGrids/Examples/AsynchMachine/package.mo
@@ -1,0 +1,6 @@
+within PowerGrids.Examples;
+
+package AsynchMachine
+  extends Modelica.Icons.ExamplesPackage;
+
+end AsynchMachine;

--- a/PowerGrids/Examples/AsynchMachine/package.order
+++ b/PowerGrids/Examples/AsynchMachine/package.order
@@ -1,0 +1,6 @@
+AM1stOrderPowerFlow
+AM1stOrderWithLinePowerFlow
+AM1stOrder
+AM1stOrderWithSlipStart
+AM1stOrderWithLine
+AM1stOrderWithLineAndSlipStart

--- a/PowerGrids/Examples/package.order
+++ b/PowerGrids/Examples/package.order
@@ -2,3 +2,4 @@ Overview
 ENTSOE
 Tutorial
 IEEE14bus
+AsynchMachine


### PR DESCRIPTION
Hello,

I started playing with the library and one part of it consisted of making a model of a first-order asynchronous machine (AM).

AM cannot be modeled in power flow computations as a PQ or PV. One option of how this can be handled is to include it's steady-state model in the power flow equations which I have tried to do in `AMBus`. I believe the results make sense although I am not sure the implementation is compatible with the philosophy of the library.

Then I proceeded to make a dynamic model of the machine. The doubts I have is regarding its initialization.

- Since `AMBus` computes active and reactive powers in the powerflow so that the machine can be initialized in steady state, I assumed that the model can be initialized as PQ and then it would initialize the slip from there. This doesn't work perfectly if one checks the example.

- The other approach I have taken is to initialize it as PQ but also used the slip computed from the powerflow model `AMBus`. This more or less works except for some differences due to, I believe, me copying these results by hand.

I would appreciate if someone more knowledgeable could comment and give tips on how this should actually be done. 