### PR TITLE
Allow PowerFlow data to be shown on diagrams

### DIFF
--- a/PowerGrids/Electrical/Branches/LineConstantImpedance.mo
+++ b/PowerGrids/Electrical/Branches/LineConstantImpedance.mo
@@ -10,14 +10,47 @@ model LineConstantImpedance "Transmission line with constant impedance"
   parameter Types.Reactance X "Series reactance";
   parameter Types.Conductance G = 0  "Shunt conductance";
   parameter Types.Susceptance B = 0 "Shunt susceptance";
+
+  parameter Boolean showPFdata=false "=true, if PowerFlow data are to be shown";
+
 equation
   k = Complex(1);
   Y = 1/Complex(R, X);
   YA = Complex(G/2, B/2);
   YB = Complex(G/2, B/2);
-annotation(
+annotation (
     Documentation(info = "<html>
 <p>Transmission line with constant series impedance R+jX and constant shunt admittance G+jB. </p>
 <p>Implemented as a child class of <a href=\"modelica://PowerGrids.Electrical.Branches.BaseClasses.PiNetwork\">PiNetwork</a>, where Ya=Yb=(G+jB)/2 and k = 1, see the corresponding documentation.</p>
-</html>"));
+</html>"), Icon(graphics={
+       Text(
+          visible=showPFdata,
+          extent={{-160,92},{-50,52}},
+          lineColor={238,46,47},
+          textString=DynamicSelect("P", String(portA.PPu, significantDigits=3))),
+       Text(
+          visible=showPFdata,
+          extent={{-166,50},{-44,12}},
+          lineColor={217,67,180},
+          textString=DynamicSelect("Q", String(portA.QPu, significantDigits=3))),
+       Text(
+          visible=showPFdata,
+          extent={{-170,-20},{-38,-56}},
+          lineColor={28,108,200},
+          textString=DynamicSelect("V", String(portA.VPu, significantDigits=3))),
+       Text(
+          visible=showPFdata,
+          extent={{48,92},{156,52}},
+          lineColor={238,46,47},
+          textString=DynamicSelect("P", String(portB.PPu, significantDigits=3))),
+       Text(
+          visible=showPFdata,
+          extent={{42,50},{168,12}},
+          lineColor={217,67,180},
+          textString=DynamicSelect("Q", String(portB.QPu, significantDigits=3))),
+       Text(
+          visible=showPFdata,
+          extent={{40,-20},{168,-56}},
+          lineColor={28,108,200},
+          textString=DynamicSelect("V", String(portB.VPu, significantDigits=3)))}));
 end LineConstantImpedance;

--- a/PowerGrids/Electrical/Branches/TransformerFixedRatio.mo
+++ b/PowerGrids/Electrical/Branches/TransformerFixedRatio.mo
@@ -1,5 +1,4 @@
 within PowerGrids.Electrical.Branches;
-
 model TransformerFixedRatio "Transformer with fixed voltage ratio"
   extends BaseClasses.PiNetwork;
   extends Icons.Transformer;
@@ -10,13 +9,46 @@ model TransformerFixedRatio "Transformer with fixed voltage ratio"
   parameter Types.Reactance X = 0 "Series reactance on B side";
   parameter Types.Conductance G = 0 "Shunt conductance on B side";
   parameter Types.Susceptance B = 0 "Shunt susceptance on B side";
+
+   parameter Boolean showPFdata=false "=true, if PowerFlow data are to be shown";
+
 equation
   k = CM.fromPolar(rFixed, thetaFixed);
   Y = Complex(1)/Complex(R, X);
   YA = Complex(0);
   YB = Complex(G, B);
-annotation(
+annotation (
     Documentation(info = "<html><head></head><body><p>Transformer with fixed voltage ratio k = rFixed*exp(j*thetaFixed). The series impedance R+jX and shunt admittance G+jB are referred to the high-voltage side B.</p><p>Step-up transformers with fixed voltage ratio can be implemented by only setting <code>rFixed</code> and leaving  <code>thetaFixed</code> to zero default value. Phase shifters can be implemented by only setting  <code>thetaFixed</code> and leaving  <code>rFixed</code> to the default of 1.</p>
 <p>Implemented as a child class of <a href=\"modelica://PowerGrids.Electrical.Branches.BaseClasses.PiNetwork\">PiNetwork</a>, where Ya=0, Yb=G+jB and k = rFixed*exp(j*thetaFixed), see the corresponding documentation.</p>
-</body></html>"));
+</body></html>"), Icon(graphics={
+        Text(
+          visible=showPFdata,
+          extent={{-162,82},{-52,46}},
+          lineColor={238,46,47},
+          textString=DynamicSelect("P", String(portA.PPu, significantDigits=3))),
+        Text(
+          visible=showPFdata,
+          extent={{-174,46},{-36,12}},
+          lineColor={217,67,180},
+          textString=DynamicSelect("Q", String(portA.QPu, significantDigits=3))),
+        Text(
+          visible=showPFdata,
+          extent={{-174,-20},{-36,-54}},
+          lineColor={28,108,200},
+          textString=DynamicSelect("V", String(portA.VPu, significantDigits=3))),
+        Text(
+          visible=showPFdata,
+          extent={{52,84},{162,48}},
+          lineColor={238,46,47},
+          textString=DynamicSelect("P", String(portB.PPu, significantDigits=3))),
+        Text(
+          visible=showPFdata,
+          extent={{36,46},{174,12}},
+          lineColor={217,67,180},
+          textString=DynamicSelect("Q", String(portB.QPu, significantDigits=3))),
+        Text(
+          visible=showPFdata,
+          extent={{38,-18},{174,-52}},
+          lineColor={28,108,200},
+          textString=DynamicSelect("V", String(portB.VPu, significantDigits=3)))}));
 end TransformerFixedRatio;

--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/PowerFlow.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/PowerFlow.mo
@@ -1,63 +1,39 @@
-within PowerGrids.Examples.Tutorial.IslandOperation;
-model PowerFlow
+within PowerGrids.Examples.Tutorial.GridOperation.Static;
+model PowerFlow "Power flow for the basic grid used in the tutorial"
   extends Modelica.Icons.Example;
-  PowerGrids.Electrical.PowerFlow.PVBus GEN1(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation (
-    Placement(visible = true, transformation(origin = {-104, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.PowerFlow.PVBus GEN2(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation (
-    Placement(visible = true, transformation(origin = {86, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadPQVoltageDependence GRIDL1(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation (
-    Placement(visible = true, transformation(origin = {-14, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL2(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation (
-    Placement(visible = true, transformation(origin = {26, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true) annotation (
-    Placement(visible = true, transformation(origin = {-80, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN1(R = 0.15e-2 * 419 ^ 2 / 500,
+  PowerGrids.Electrical.PowerFlow.PVBus GEN(P = -4.75e+8, SNom = 5e+8, U = 20825.8, UNom = 21000, generatorConvention = false, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {-50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+8, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {-30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN( R = 0.15e-2 * 419 ^ 2 / 500,
     SNom=500000000,
     UNomA=21000,
-    UNomB=419000,                                                                                                                      X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true,
-    showPFdata=true,                                                                                                                                                                          portVariablesPu = true, rFixed = 419 / 21) annotation (
-    Placement(visible = true, transformation(origin = {-54, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.PowerFlow.SlackBus NTHV1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation (
-    Placement(visible = true, transformation(origin = {-24, 0}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.LineConstantImpedance LINE(
-    UNomA=419000,
-    UNomB=419000,                                           R = 10,
-    SNom=500000000,
-    UNom=380000,                                                                                X = 100, portVariablesPhases = true,
-    showPFdata=true,                                                                                                                 portVariablesPu = true) annotation (
-    Placement(visible = true, transformation(origin = {6, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTHV2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation (
-    Placement(visible = true, transformation(origin = {36, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN2(R = 0.15e-2 * 419 ^ 2 / 500,
-    SNom=500000000,
-    UNomA=21000,
-    UNomB=419000,                                                                                                                      X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true,
-    showPFdata=true,                                                                                                                                                                          portVariablesPu = true, rFixed = 419 / 21) annotation (
-    Placement(visible = true, transformation(origin = {60, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
+    UNomB=419000,                                                                                                                     X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true,
+    showPFdata=true,                                                                                                                                                                         portVariablesPu = true, rFixed = 419 / 21)  annotation (
+    Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
   inner PowerGrids.Electrical.System systemPowerGrids annotation (
-    Placement(visible = true, transformation(origin = {-64, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin = {-30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.PQBus GRIDL(P = 4.75e+8, Q = 7.6e+7, SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {60, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.PowerFlow.SlackBus GRID(SNom = 5e+8, U = 399000, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
+    Placement(visible = true, transformation(origin = {60, 20}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
 equation
-  connect(NTLV1.terminal, TGEN1.terminalA) annotation (
-    Line(points = {{-80, -1.42109e-15}, {-64, -1.42109e-15}}));
-  connect(TGEN1.terminalB, NTHV1.terminal) annotation (
-    Line(points = {{-44, 0}, {-24, 0}}));
-  connect(NTHV1.terminal, GRIDL1.terminal) annotation (
-    Line(points = {{-24, -1.42109e-15}, {-14, -1.42109e-15}, {-14, -26}}));
-  connect(GEN1.terminal, NTLV1.terminal) annotation (
-    Line(points = {{-104, 0}, {-80, 0}}));
-  connect(LINE.terminalA, NTHV1.terminal) annotation (
-    Line(points = {{-4, 0}, {-24, 0}}));
-  connect(LINE.terminalB, NTHV2.terminal) annotation (
-    Line(points = {{16, 0}, {36, 0}}));
-  connect(NTHV2.terminal, GRIDL2.terminal) annotation (
-    Line(points = {{36, -1.42109e-15}, {26, -1.42109e-15}, {26, -26}}));
-  connect(NTHV2.terminal, TGEN2.terminalB) annotation (
-    Line(points = {{36, -1.42109e-15}, {50, -1.42109e-15}}));
-  connect(TGEN2.terminalA, GEN2.terminal) annotation (
-    Line(points = {{70, 0}, {86, 0}}));
+  connect(GEN.terminal, NTLV.terminal) annotation (
+    Line(points = {{-50, 0}, {-30, 0}, {-30, 0}, {-30, 0}}));
+  connect(NTLV.terminal, TGEN.terminalA) annotation (
+    Line(points = {{-30, 0}, {-10, 0}, {-10, 0}, {-10, 0}}));
+  connect(TGEN.terminalB, NTHV.terminal) annotation (
+    Line(points = {{10, 0}, {30, 0}, {30, 0}, {30, 0}}));
+  connect(NTHV.terminal, GRID.terminal) annotation (
+    Line(points = {{30, 0}, {32, 0}, {32, 20}, {60, 20}, {60, 20}}));
+  connect(GRIDL.terminal, NTHV.terminal) annotation (
+    Line(points = {{60, -20}, {32, -20}, {32, 0}, {30, 0}}));
   annotation (
-    Icon(coordinateSystem(grid = {0.1, 0.1})),
-    Diagram(coordinateSystem(extent = {{-120, 20}, {100, -40}}, grid = {0.5, 0.5})),
-    experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-06, Interval = 0.002),
-    __OpenModelica_simulationFlags(lv = "LOG_STATS", outputFormat = "mat", s = "dassl"));
+    Icon(coordinateSystem(grid={2,2}, extent={{-100,-100},{100,100}})),
+    Diagram(coordinateSystem(extent={{-60,-40},{80,40}},      grid={2,2})),
+    experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-6, Interval = 0.002),
+    __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
+    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"));
 end PowerFlow;

--- a/PowerGrids/Examples/Tutorial/GridOperation/Static/PowerFlow.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Static/PowerFlow.mo
@@ -1,35 +1,63 @@
-within PowerGrids.Examples.Tutorial.GridOperation.Static;
-model PowerFlow "Power flow for the basic grid used in the tutorial"
+within PowerGrids.Examples.Tutorial.IslandOperation;
+model PowerFlow
   extends Modelica.Icons.Example;
-  PowerGrids.Electrical.PowerFlow.PVBus GEN(P = -4.75e+8, SNom = 5e+8, U = 20825.8, UNom = 21000, generatorConvention = false, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {-50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Buses.Bus NTLV(SNom = 5e+8, UNom = 21000, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {-30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+8, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21)  annotation (
-    Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTHV(SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.PowerFlow.PVBus GEN1(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation (
+    Placement(visible = true, transformation(origin = {-104, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.PVBus GEN2(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation (
+    Placement(visible = true, transformation(origin = {86, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadPQVoltageDependence GRIDL1(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation (
+    Placement(visible = true, transformation(origin = {-14, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL2(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation (
+    Placement(visible = true, transformation(origin = {26, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true) annotation (
+    Placement(visible = true, transformation(origin = {-80, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN1(R = 0.15e-2 * 419 ^ 2 / 500,
+    SNom=500000000,
+    UNomA=21000,
+    UNomB=419000,                                                                                                                      X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true,
+    showPFdata=true,                                                                                                                                                                          portVariablesPu = true, rFixed = 419 / 21) annotation (
+    Placement(visible = true, transformation(origin = {-54, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.SlackBus NTHV1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation (
+    Placement(visible = true, transformation(origin = {-24, 0}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.LineConstantImpedance LINE(
+    UNomA=419000,
+    UNomB=419000,                                           R = 10,
+    SNom=500000000,
+    UNom=380000,                                                                                X = 100, portVariablesPhases = true,
+    showPFdata=true,                                                                                                                 portVariablesPu = true) annotation (
+    Placement(visible = true, transformation(origin = {6, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTHV2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation (
+    Placement(visible = true, transformation(origin = {36, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN2(R = 0.15e-2 * 419 ^ 2 / 500,
+    SNom=500000000,
+    UNomA=21000,
+    UNomB=419000,                                                                                                                      X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true,
+    showPFdata=true,                                                                                                                                                                          portVariablesPu = true, rFixed = 419 / 21) annotation (
+    Placement(visible = true, transformation(origin = {60, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
   inner PowerGrids.Electrical.System systemPowerGrids annotation (
-    Placement(visible = true, transformation(origin = {-30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.PowerFlow.PQBus GRIDL(P = 4.75e+8, Q = 7.6e+7, SNom = 5e+8, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {60, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.PowerFlow.SlackBus GRID(SNom = 5e+8, U = 399000, UNom = 380000, portVariablesPhases = true, portVariablesPu = true)  annotation (
-    Placement(visible = true, transformation(origin = {60, 20}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
+    Placement(visible = true, transformation(origin = {-64, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(GEN.terminal, NTLV.terminal) annotation (
-    Line(points = {{-50, 0}, {-30, 0}, {-30, 0}, {-30, 0}}));
-  connect(NTLV.terminal, TGEN.terminalA) annotation (
-    Line(points = {{-30, 0}, {-10, 0}, {-10, 0}, {-10, 0}}));
-  connect(TGEN.terminalB, NTHV.terminal) annotation (
-    Line(points = {{10, 0}, {30, 0}, {30, 0}, {30, 0}}));
-  connect(NTHV.terminal, GRID.terminal) annotation (
-    Line(points = {{30, 0}, {32, 0}, {32, 20}, {60, 20}, {60, 20}}));
-  connect(GRIDL.terminal, NTHV.terminal) annotation (
-    Line(points = {{60, -20}, {32, -20}, {32, 0}, {30, 0}}));
+  connect(NTLV1.terminal, TGEN1.terminalA) annotation (
+    Line(points = {{-80, -1.42109e-15}, {-64, -1.42109e-15}}));
+  connect(TGEN1.terminalB, NTHV1.terminal) annotation (
+    Line(points = {{-44, 0}, {-24, 0}}));
+  connect(NTHV1.terminal, GRIDL1.terminal) annotation (
+    Line(points = {{-24, -1.42109e-15}, {-14, -1.42109e-15}, {-14, -26}}));
+  connect(GEN1.terminal, NTLV1.terminal) annotation (
+    Line(points = {{-104, 0}, {-80, 0}}));
+  connect(LINE.terminalA, NTHV1.terminal) annotation (
+    Line(points = {{-4, 0}, {-24, 0}}));
+  connect(LINE.terminalB, NTHV2.terminal) annotation (
+    Line(points = {{16, 0}, {36, 0}}));
+  connect(NTHV2.terminal, GRIDL2.terminal) annotation (
+    Line(points = {{36, -1.42109e-15}, {26, -1.42109e-15}, {26, -26}}));
+  connect(NTHV2.terminal, TGEN2.terminalB) annotation (
+    Line(points = {{36, -1.42109e-15}, {50, -1.42109e-15}}));
+  connect(TGEN2.terminalA, GEN2.terminal) annotation (
+    Line(points = {{70, 0}, {86, 0}}));
   annotation (
-    Icon(coordinateSystem(grid={2,2}, extent={{-100,-100},{100,100}})),
-    Diagram(coordinateSystem(extent={{-60,-40},{80,40}},      grid={2,2})),
-    experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-6, Interval = 0.002),
-    __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
-    __OpenModelica_simulationFlags(nls="kinsol", lv="LOG_INIT_HOMOTOPY", homotopyOnFirstTry="()"));
+    Icon(coordinateSystem(grid = {0.1, 0.1})),
+    Diagram(coordinateSystem(extent = {{-120, 20}, {100, -40}}, grid = {0.5, 0.5})),
+    experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-06, Interval = 0.002),
+    __OpenModelica_simulationFlags(lv = "LOG_STATS", outputFormat = "mat", s = "dassl"));
 end PowerFlow;

--- a/PowerGrids/Examples/Tutorial/IslandOperation/PowerFlow.mo
+++ b/PowerGrids/Examples/Tutorial/IslandOperation/PowerFlow.mo
@@ -1,51 +1,63 @@
 within PowerGrids.Examples.Tutorial.IslandOperation;
-
 model PowerFlow
   extends Modelica.Icons.Example;
-  PowerGrids.Electrical.PowerFlow.PVBus GEN1(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation(
+  PowerGrids.Electrical.PowerFlow.PVBus GEN1(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation (
     Placement(visible = true, transformation(origin = {-104, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.PowerFlow.PVBus GEN2(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation(
-    Placement(visible = true, transformation(origin = {100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadPQVoltageDependence GRIDL1(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation(
-    Placement(visible = true, transformation(origin = {-10, -46}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL2(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation(
-    Placement(visible = true, transformation(origin = {30, -46}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTLV1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true) annotation(
+  PowerGrids.Electrical.PowerFlow.PVBus GEN2(P = -4.5088e+08, SNom = 5e+08, U = 20825, UNom = 21000) annotation (
+    Placement(visible = true, transformation(origin = {86, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadPQVoltageDependence GRIDL1(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation (
+    Placement(visible = true, transformation(origin = {-14, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL2(PRefConst = 4.5e+08, QRefConst = 200e6, SNom = 5e+08, UNom = 380000, portVariablesPhases = true) annotation (
+    Placement(visible = true, transformation(origin = {26, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTLV1(SNom = 5e+08, UNom = 21000, portVariablesPhases = true, portVariablesPu = true) annotation (
     Placement(visible = true, transformation(origin = {-80, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN1(R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21) annotation(
-    Placement(visible = true, transformation(origin = {-50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.PowerFlow.SlackBus NTHV1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation(
-    Placement(visible = true, transformation(origin = {-20, 0}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.LineConstantImpedance LINE(R = 10, SNom = 5e+8, UNom = 380000, X = 100, portVariablesPhases = true, portVariablesPu = true) annotation(
-    Placement(visible = true, transformation(origin = {10, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Electrical.Buses.Bus NTHV2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation(
-    Placement(visible = true, transformation(origin = {40, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN2(R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, portVariablesPu = true, rFixed = 419 / 21) annotation(
-    Placement(visible = true, transformation(origin = {70, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
-  inner Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN1(R = 0.15e-2 * 419 ^ 2 / 500,
+    SNom=500000000,
+    UNomA=21000,
+    UNomB=419000,                                                                                                                      X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true,
+    showPFdata=true,                                                                                                                                                                          portVariablesPu = true, rFixed = 419 / 21) annotation (
+    Placement(visible = true, transformation(origin = {-54, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.PowerFlow.SlackBus NTHV1(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation (
+    Placement(visible = true, transformation(origin = {-24, 0}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.LineConstantImpedance LINE(
+    UNomA=419000,
+    UNomB=419000,                                           R = 10,
+    SNom=500000000,
+    UNom=380000,                                                                                X = 100, portVariablesPhases = true,
+    showPFdata=true,                                                                                                                 portVariablesPu = true) annotation (
+    Placement(visible = true, transformation(origin = {6, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Electrical.Buses.Bus NTHV2(SNom = 5e+08, UNom = 380000, portVariablesPhases = true, portVariablesPu = true) annotation (
+    Placement(visible = true, transformation(origin = {36, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN2(R = 0.15e-2 * 419 ^ 2 / 500,
+    SNom=500000000,
+    UNomA=21000,
+    UNomB=419000,                                                                                                                      X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true,
+    showPFdata=true,                                                                                                                                                                          portVariablesPu = true, rFixed = 419 / 21) annotation (
+    Placement(visible = true, transformation(origin = {60, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
+  inner PowerGrids.Electrical.System systemPowerGrids annotation (
+    Placement(visible = true, transformation(origin = {-64, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(NTLV1.terminal, TGEN1.terminalA) annotation(
-    Line(points = {{-80, 0}, {-60, 0}}));
-  connect(TGEN1.terminalB, NTHV1.terminal) annotation(
-    Line(points = {{-40, 0}, {-20, 0}}));
-  connect(NTHV1.terminal, GRIDL1.terminal) annotation(
-    Line(points = {{-20, 0}, {-10, 0}, {-10, -46}}));
-  connect(GEN1.terminal, NTLV1.terminal) annotation(
+  connect(NTLV1.terminal, TGEN1.terminalA) annotation (
+    Line(points = {{-80, -1.42109e-15}, {-64, -1.42109e-15}}));
+  connect(TGEN1.terminalB, NTHV1.terminal) annotation (
+    Line(points = {{-44, 0}, {-24, 0}}));
+  connect(NTHV1.terminal, GRIDL1.terminal) annotation (
+    Line(points = {{-24, -1.42109e-15}, {-14, -1.42109e-15}, {-14, -26}}));
+  connect(GEN1.terminal, NTLV1.terminal) annotation (
     Line(points = {{-104, 0}, {-80, 0}}));
-  connect(LINE.terminalA, NTHV1.terminal) annotation(
-    Line(points = {{0, 0}, {-20, 0}}));
-  connect(LINE.terminalB, NTHV2.terminal) annotation(
-    Line(points = {{20, 0}, {40, 0}}));
-  connect(NTHV2.terminal, GRIDL2.terminal) annotation(
-    Line(points = {{40, 0}, {30, 0}, {30, -46}}));
-  connect(NTHV2.terminal, TGEN2.terminalB) annotation(
-    Line(points = {{40, 0}, {60, 0}, {60, 0}, {60, 0}}));
-  connect(TGEN2.terminalA, GEN2.terminal) annotation(
-    Line(points = {{80, 0}, {100, 0}, {100, 0}, {100, 0}}));
-  annotation(
+  connect(LINE.terminalA, NTHV1.terminal) annotation (
+    Line(points = {{-4, 0}, {-24, 0}}));
+  connect(LINE.terminalB, NTHV2.terminal) annotation (
+    Line(points = {{16, 0}, {36, 0}}));
+  connect(NTHV2.terminal, GRIDL2.terminal) annotation (
+    Line(points = {{36, -1.42109e-15}, {26, -1.42109e-15}, {26, -26}}));
+  connect(NTHV2.terminal, TGEN2.terminalB) annotation (
+    Line(points = {{36, -1.42109e-15}, {50, -1.42109e-15}}));
+  connect(TGEN2.terminalA, GEN2.terminal) annotation (
+    Line(points = {{70, 0}, {86, 0}}));
+  annotation (
     Icon(coordinateSystem(grid = {0.1, 0.1})),
-    Diagram(coordinateSystem(extent = {{-160, -100}, {160, 100}}, grid = {0.5, 0.5})),
+    Diagram(coordinateSystem(extent = {{-120, 20}, {100, -40}}, grid = {0.5, 0.5})),
     experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-06, Interval = 0.002),
     __OpenModelica_simulationFlags(lv = "LOG_STATS", outputFormat = "mat", s = "dassl"));
 end PowerFlow;


### PR DESCRIPTION
This PR allows the following PowerFlow data to be shown on diagrams: Ppu, Qpu, Vpu.
It applies to
- Electrical.Branches.TransformerFizedRatio
- Electrical.Branches.LineConstantImpedance
If this PR is accepted, in a second PR I can extend this to other components.

This is especially useful for PowerFlow studies, since only the final values of "simulations" are of interest, and retrieving data from huge sets of output variables is a lengthy process. 
With this new feature, the user will have an immediate view of the PowerFlow output.

This visualization is switched off by default for consistency with previous models.
It has been switched on on the following models: 
- Tutorial.GridOperation.Static.PowerFlow
- Tutorial.IslandOperation.PowerFlow