### PR TITLE
Different terminals colors

### DIFF
--- a/PowerGrids/Electrical/BaseClasses/PortAC.mo
+++ b/PowerGrids/Electrical/BaseClasses/PortAC.mo
@@ -1,5 +1,4 @@
 within PowerGrids.Electrical.BaseClasses;
-
 model PortAC "AC port computing auxiliary quantities"
   parameter Types.Power   SNom(start = 100e6) "Nominal or rated power";
   parameter Types.Voltage UNom(start = 400e3) "Nominal or rated phase-to-phase voltage";
@@ -10,7 +9,7 @@ model PortAC "AC port computing auxiliary quantities"
   parameter Types.Power QStart "Start value of reactive power flowing into port";
   parameter Types.Voltage UStart = UNom "Start value of phase-to-phase voltage modulus";
   parameter Types.Angle UPhaseStart = 0 "Start value of voltage phase";
-  
+
   parameter Boolean portVariablesPhases = false "Compute voltage and current phases for monitoring purposes only" annotation(Evaluate = true);
   constant Boolean portVariablesPu = true "Add per-unit variables to model";
   constant Boolean generatorConvention = false "Add currents with generator convention (i > 0 when exiting the device) to model";
@@ -18,7 +17,7 @@ model PortAC "AC port computing auxiliary quantities"
   // Computed parameters
   final parameter Types.Voltage VBase = UBase/sqrt(3) "Base phase-to-ground voltage";
   final parameter Types.Current IBase = SBase/(3*VBase) "Base current";
-  
+
   final parameter Types.Voltage VStart = UStart/sqrt(3) "Start value of phase-to ground voltage modulus";
   final parameter Types.Current IStart = sqrt(PStart^2 + QStart^2)/(3*VStart) "Start value of current modulus";
 
@@ -26,7 +25,7 @@ model PortAC "AC port computing auxiliary quantities"
     "Start value of phase-to-ground voltage phasor";
   final parameter Types.ComplexCurrent iStart = CM.conj(Complex(PStart,QStart)/(Complex(3)*vStart))
     "Start value of current phasor flowing into the port";
-  
+
   connector InputComplexVoltage = input Types.ComplexVoltage "Marks potential input for balancedness check without requiring binding equation";
   connector InputComplexCurrent = input Types.ComplexCurrent "Marks potential input for balancedness check without requiring binding equation";
 
@@ -42,28 +41,28 @@ model PortAC "AC port computing auxiliary quantities"
      "Complex power flowing into the port";
   Types.ActivePower   P(nominal = SBase, start = PStart) = S.re "Active power flowing into the port";
   Types.ReactivePower Q(nominal = SBase, start = QStart) = S.im "Reactive power flowing into the port";
-  
+
   Types.Voltage U(nominal = UBase, start = UStart) = CM.'abs'(u) "Port voltage absolute value (phase-to-phase)";
   Types.Current I(nominal = IBase, start = IStart) = CM.'abs'(i) "Port current (positive entering)";
 
-  Types.PerUnit        PPu(start = PStart/SBase) = if portVariablesPu then S.re/SBase else 0 "Active power flowing into the port in p.u. (base SBase)" annotation(
+  Types.PerUnit        PPu(start = PStart/SBase) = if portVariablesPu then S.re/SBase else 0 "Active power flowing into the port in p.u. (base SBase)" annotation (
   HideResult = portVariablesPu);
-  Types.PerUnit        QPu(start = QStart/SBase) = if portVariablesPu then S.im/SBase else 0 "Reactive power flowing into the port in p.u. (base SBase)" annotation(
+  Types.PerUnit        QPu(start = QStart/SBase) = if portVariablesPu then S.im/SBase else 0 "Reactive power flowing into the port in p.u. (base SBase)" annotation (
   HideResult = portVariablesPu);
-  Types.ComplexPerUnit vPu(re(start = vStart.re/VBase),im(start = vStart.im/VBase)) = if portVariablesPu then u*(1/UBase) else Complex(0) "Complex voltage across the port in p.u. (base VBase)"  annotation(
+  Types.ComplexPerUnit vPu(re(start = vStart.re/VBase),im(start = vStart.im/VBase)) = if portVariablesPu then u*(1/UBase) else Complex(0) "Complex voltage across the port in p.u. (base VBase)"  annotation (
   HideResult = portVariablesPu);
-  SI.PerUnit           VPu(start = VStart/VBase) = if portVariablesPu then U/UBase else 0 "Absolute value of voltage across the port in p.u. (base VBase)" annotation(
+  SI.PerUnit           VPu(start = VStart/VBase) = if portVariablesPu then U/UBase else 0 "Absolute value of voltage across the port in p.u. (base VBase)" annotation (
   HideResult = portVariablesPu);
-  Types.ComplexPerUnit iPu(re(start = iStart.re/IBase), im(start = iStart.im/IBase)) = if portVariablesPu then i*(1/IBase) else Complex(0) "Complex current flowing into the port in p.u. (base IBase)" annotation(
+  Types.ComplexPerUnit iPu(re(start = iStart.re/IBase), im(start = iStart.im/IBase)) = if portVariablesPu then i*(1/IBase) else Complex(0) "Complex current flowing into the port in p.u. (base IBase)" annotation (
   HideResult = portVariablesPu);
-  SI.PerUnit           IPu(start = IStart/IBase) = if portVariablesPu then I/IBase else 0 "Absolute value of complex current flowing into the port in p.u. (base IBase)" annotation(
+  SI.PerUnit           IPu(start = IStart/IBase) = if portVariablesPu then I/IBase else 0 "Absolute value of complex current flowing into the port in p.u. (base IBase)" annotation (
   HideResult = portVariablesPu);
-  
-  Types.Angle UPhase(start = UPhaseStart) = if portVariablesPhases then atan2(v.im, v.re) else 0 "Phase of voltage across the port"  annotation(
+
+  Types.Angle UPhase(start = UPhaseStart) = if portVariablesPhases then atan2(v.im, v.re) else 0 "Phase of voltage across the port"  annotation (
   HideResult = portVariablesPhases);
-  Types.Angle IPhase(start = CM.arg(iStart)) = if portVariablesPhases then atan2(i.im, i.re) else 0 "Phase of current into the port" annotation(
+  Types.Angle IPhase(start = CM.arg(iStart)) = if portVariablesPhases then atan2(i.im, i.re) else 0 "Phase of current into the port" annotation (
   HideResult = portVariablesPhases);
-  
+
   Types.ComplexCurrent iGen(re(nominal = IBase, start = -iStart.re),
                             im(nominal = IBase, start = -iStart.im)) = -i "Port current, generator convention";
   Types.ActivePower PGen(nominal = SBase, start = -PStart) = -S.re "Active power flowing out of the port";
@@ -71,13 +70,13 @@ model PortAC "AC port computing auxiliary quantities"
   Types.PerUnit PGenPu(start = -PStart/SBase) = -PPu "Active power flowing out of the port in p.u. (base SBase)";
   Types.PerUnit QGenPu(start = -QStart/SBase) = -QPu "Reactive power flowing out of the port in p.u. (base SBase)";
   Types.ComplexPerUnit iGenPu(re(start = -iStart.re/IBase),im(start = -iStart.im/IBase)) = -iPu "Complex current flowing out of the port in p.u. (base IBase)";
-  SI.PerUnit IGenPu(start = IStart/IBase) = if portVariablesPu and generatorConvention then I/IBase else 0 "Absolute value of current flowing out of the port in p.u. (base IBase)" annotation(
+  SI.PerUnit IGenPu(start = IStart/IBase) = if portVariablesPu and generatorConvention then I/IBase else 0 "Absolute value of current flowing out of the port in p.u. (base IBase)" annotation (
   HideResult = portVariablesPu and generatorConvention);
-  annotation(
+  annotation (
     Documentation(info = "<html>
 <p>This model computes quantities associated to an AC port that can be useful or relevant for modelling and monitoring purposes, such as the complex power flow, the absolute value of the phase-to-phase voltage, the angle of the current, or various per-unit quantities. The phase-to-ground voltage and line current phasors must be assigned as inputs.</p>
 
 <p>Per-unit quantities, angles and quantities using the generator convention are defined if the corresponding parameters <code>portVariablesPu</code>, <code>portVariablesAngles</code>, and <code>generatorConvention</code> are set to true, respectively.</p>
 </html>"),
-    Icon(graphics = {Rectangle(extent = {{-100, 100}, {100, -100}})}));
+    Icon(graphics={  Rectangle(extent = {{-100, 100}, {100, -100}})}));
 end PortAC;

--- a/PowerGrids/Electrical/BaseClasses/TwoPortAC.mo
+++ b/PowerGrids/Electrical/BaseClasses/TwoPortAC.mo
@@ -1,5 +1,4 @@
 within PowerGrids.Electrical.BaseClasses;
-
 partial model TwoPortAC "Base class for two-port AC components"
   parameter Types.Voltage UNomA(start = 400e3) "Nominal/rated voltage, port A" annotation(Evaluate = true);
   parameter Types.Voltage UNomB = UNomA "Nominal/rated voltage, port B" annotation(Evaluate = true);
@@ -27,10 +26,26 @@ partial model TwoPortAC "Base class for two-port AC components"
   parameter Types.ReactivePower QStartB = 0 "Start value of reactive power flowing into port B"
     annotation(Dialog(tab = "Initialization"));
 
-  PowerGrids.Interfaces.TerminalAC terminalA annotation(
-    Placement(visible = true, transformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Interfaces.TerminalAC terminalB annotation(
-    Placement(visible = true, transformation(origin = {100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PowerGrids.Interfaces.TerminalA terminalA annotation (Placement(
+      visible=true,
+      transformation(
+        origin={-100,0},
+        extent={{-10,-10},{10,10}},
+        rotation=0),
+      iconTransformation(
+        origin={-100,0},
+        extent={{-10,-10},{10,10}},
+        rotation=0)));
+  PowerGrids.Interfaces.TerminalB terminalB annotation (Placement(
+      visible=true,
+      transformation(
+        origin={100,0},
+        extent={{-10,-10},{10,10}},
+        rotation=0),
+      iconTransformation(
+        origin={100,0},
+        extent={{-10,-10},{10,10}},
+        rotation=0)));
   PortAC portA(final v = terminalA.v, final i = terminalA.i,
                final UNom = UNomA, final SNom = SNom,
                final portVariablesPu = portVariablesPu,
@@ -54,7 +69,7 @@ partial model TwoPortAC "Base class for two-port AC components"
 
   Types.ComplexPower Sbal = portA.S + portB.S if computePowerBalance "Complex power balance";
   outer Electrical.System systemPowerGrids "Reference to system object";
-  annotation(
+  annotation (
     Documentation(info = "<html><head></head><body><p>This is the base class for all the components with two AC terminals. It contains two corresponding <code>PortAC</code> components to compute useful quantities for modelling and monitoring purposes.</p>
 </body></html>"));
 end TwoPortAC;

--- a/PowerGrids/Interfaces/package.mo
+++ b/PowerGrids/Interfaces/package.mo
@@ -3,6 +3,36 @@ within PowerGrids;
 package Interfaces "Interfaces package"
   extends Modelica.Icons.InterfacesPackage;
 
+connector TerminalA "Terminal for phasor-based AC connections"
+  Types.ComplexVoltage v "Phase-to-ground voltage phasor";
+  flow Types.ComplexCurrent i "Line current phasor";
+  annotation (
+    Icon(coordinateSystem(extent = {{-100, -100}, {100, 100}}, preserveAspectRatio = true, initialScale = 1, grid = {2, 2}), graphics={  Rectangle(origin = {92, 3}, fillColor = {85, 170, 255},
+            fillPattern =                                                                                                                                                                                      FillPattern.Solid, extent = {{-192, 97}, {8, -103}})}),
+    Diagram(coordinateSystem(extent = {{-100, -100}, {100, 100}}, preserveAspectRatio = true, initialScale = 1, grid = {2, 2})),
+Documentation(info = "<html><head></head><body><p>
+The TerminalAC connector represents a three-phase AC terminal. Voltages and currents are assumed to be quasi-sinusoidal and are thus represented by \"phasors\". The phasor gives the amplitude and rotation of the three-phase system with respect to a reference rotating frame. </p>
+<p>
+The information about the rotating frame cannot be carried by the connector because, with the Modelica 3.x semantics of overconstraind connectors, it won't be possible to dynamically split and merge synchronous island by opening and closing breakers during the simulation. As this feature is essential for the modelling of power transmission systems at the national or continental scale, the reference frame information is instead managed by the system object. For the correctness of models, all the components which are effectively interconnected (i.e., not through an open circuit breaker) must refer to the same reference frequency.
+</p>
+</body></html>"));
+end TerminalA;
+
+connector TerminalB "Terminal for phasor-based AC connections"
+  Types.ComplexVoltage v "Phase-to-ground voltage phasor";
+  flow Types.ComplexCurrent i "Line current phasor";
+  annotation (
+    Icon(coordinateSystem(extent = {{-100, -100}, {100, 100}}, preserveAspectRatio = true, initialScale = 1, grid = {2, 2}), graphics={Rectangle(origin = {92, 3}, fillColor = {255, 255, 255}, fillPattern = FillPattern.Solid, extent = {{-192, 97}, {8, -103}})}),
+    Diagram(coordinateSystem(extent = {{-100, -100}, {100, 100}}, preserveAspectRatio = true, initialScale = 1, grid = {2, 2})),
+Documentation(info = "<html><head></head><body><p>
+The TerminalAC connector represents a three-phase AC terminal. Voltages and currents are assumed to be quasi-sinusoidal and are thus represented by \"phasors\". The phasor gives the amplitude and rotation of the three-phase system with respect to a reference rotating frame. </p>
+<p>
+The information about the rotating frame cannot be carried by the connector because, with the Modelica 3.x semantics of overconstraind connectors, it won't be possible to dynamically split and merge synchronous island by opening and closing breakers during the simulation. As this feature is essential for the modelling of power transmission systems at the national or continental scale, the reference frame information is instead managed by the system object. For the correctness of models, all the components which are effectively interconnected (i.e., not through an open circuit breaker) must refer to the same reference frequency.
+</p>
+</body></html>"));
+end TerminalB;
+
+
   connector TerminalAC "Terminal for phasor-based AC connections"
     Types.ComplexVoltage v "Phase-to-ground voltage phasor";
     flow Types.ComplexCurrent i "Line current phasor";

--- a/PowerGrids/Interfaces/package.order
+++ b/PowerGrids/Interfaces/package.order
@@ -1,1 +1,3 @@
+TerminalA
+TerminalB
 TerminalAC


### PR DESCRIPTION
This PR makes PowerGrids use two different visual aspects for the two terminals of any two-port components.
This makes it more consistent with nearly all MSL models. It also eases understanding simulation results a lot: the results refer to different ports, and having immediate visual info on what PortA (terminalA) and PortB (TerminalB) are is very convenient.

This result is obtained very simply:
- in PowerGrids.Interfaces TerminalA and TermialB are defined
- in PowerGrits.Electrical.Baseclasses TwoPortAC is modified so that PowerA is of type PortA, portB of type portB (previously both were of PortAC Type)