### PR TITLE
Pr#19 rewriting - add ifPu and enhance generator icon (and others icons) 

### DIFF
--- a/PowerGrids/Electrical/Buses/InfiniteBusVariableVoltage.mo
+++ b/PowerGrids/Electrical/Buses/InfiniteBusVariableVoltage.mo
@@ -1,52 +1,48 @@
 within PowerGrids.Electrical.Buses;
+
 model InfiniteBusVariableVoltage
-  extends BaseClasses.BusBase(
-    e = CM.fromPolar(UAux/sqrt(3), thetaAux),
-    Z = Complex(R, X));
+  extends BaseClasses.BusBase(e = CM.fromPolar(UAux/sqrt(3), thetaAux), Z = Complex(R, X));
   extends Icons.Bus;
-  parameter Types.Voltage UFixed = UNom "Fixed source voltage modulus, phase-to-phase" annotation(Dialog(enable = not useThetaIn));
-  parameter Types.Angle thetaFixed = 0 "Fixed angle of source voltage" annotation(Dialog(enable = not useThetaIn));
+  parameter Types.Voltage UFixed = UNom "Fixed source voltage modulus, phase-to-phase" annotation(
+    Dialog(enable = not useThetaIn));
+  parameter Types.Angle thetaFixed = 0 "Fixed angle of source voltage" annotation(
+    Dialog(enable = not useThetaIn));
   parameter Boolean useUIn = false "Use external input for source voltage magnitude" annotation(
-   Dialog(group = "external inputs"), choices(checkBox = true));
+    Dialog(group = "external inputs"),
+    choices(checkBox = true));
   parameter Boolean useThetaIn = false "Use external input for source voltage angle" annotation(
-   Dialog(group = "external inputs"), choices(checkBox = true));
+    Dialog(group = "external inputs"),
+    choices(checkBox = true));
   parameter Types.Resistance R = 0 "Series resistance";
   parameter Types.Reactance X = 0 "Series reactance";
-
   Modelica.Blocks.Interfaces.RealInput UIn(unit = "V", displayUnit = "kV") if useUIn "Source voltage modulus input, phase-to-phase, V" annotation(
     Placement(visible = true, transformation(origin = {-98, 40}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   Modelica.Blocks.Interfaces.RealInput thetaIn(unit = "rad", displayUnit = "deg") if useThetaIn "Source voltage phase angle input, rad" annotation(
     Placement(visible = true, transformation(origin = {-98, -26}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
-
 protected
   // Auxiliary hidden connectors to manage the conditional connectors
   Modelica.Blocks.Interfaces.RealInput UAux "Source voltage modulus, phase-to-phase";
   Modelica.Blocks.Interfaces.RealInput thetaAux "Source voltage phase angle";
-
 equation
 // Conditional connectors
-   connect(UIn, UAux);
-   if not useUIn then
-     UAux = UFixed;
-   end if;
-
-   connect(thetaIn, thetaAux);
-   if not useThetaIn then
-     thetaAux = thetaFixed;
-   end if;
-
-   assert(UAux >= 0, "Magnitude must be positive");
-   
-  // Overconstrained connector
+  connect(UIn, UAux);
+  if not useUIn then
+    UAux = UFixed;
+  end if;
+  connect(thetaIn, thetaAux);
+  if not useThetaIn then
+    thetaAux = thetaFixed;
+  end if;
+  assert(UAux >= 0, "Magnitude must be positive");
+// Overconstrained connector
   Connections.potentialRoot(terminalAC.omegaRefPu);
   if Connections.isRoot(terminalAC.omegaRefPu) then
-     terminalAC.omegaRefPu = 1;
-  end if;   
-
+    terminalAC.omegaRefPu = 1;
+  end if;
   annotation(
-    Icon(coordinateSystem(grid = {0.1, 0.1})),
+    Icon(coordinateSystem(grid = {0.1, 0.1}), graphics = {Rectangle(origin = {-79, 0}, extent = {{-1, 60}, {1, -60}})}),
     Diagram(coordinateSystem(extent = {{-200, -100}, {200, 100}})),
-  Documentation(info = "<html>
+    Documentation(info = "<html>
 <p>Infinite bus model with voltage e. The port voltage is v = e + Zi, where i is the current entering the bus. The default value of the series impedance Z = R + jX is zero.</p>
 <p>The magnitude and angle of the voltage e can provided by external input connectors. If useUin = true, the UIn input is used to set the magnitude of voltage e, otherwise the constant value UFixed is used.</p>
 <p>Similarly, if useThetaIn = true, the thetaIn input is used to set the phase angle of voltage e, otherwise the constant value thetaFixed is used.</p>

--- a/PowerGrids/Electrical/Loads/LoadImpedancePQInputs.mo
+++ b/PowerGrids/Electrical/Loads/LoadImpedancePQInputs.mo
@@ -13,7 +13,7 @@ model LoadImpedancePQInputs "Load model with impedance specified by PRefIn and Q
   Modelica.Blocks.Interfaces.RealInput QRefIn(unit="var", displayUnit = "MVA") "Reactive reference power at VPu = 1, var" annotation(
     Placement(visible = true, transformation(origin = {-100, -44}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -100}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   annotation(
-    Icon(coordinateSystem(grid = {0.1, 0.1})),
+    Icon(coordinateSystem(grid = {0.1, 0.1}), graphics = {Rectangle(origin = {-79, -70}, extent = {{-1, 50}, {1, -50}}), Line(origin = {-45.9763, -70.2767}, points = {{-32, 0}, {26, 0}})}),
     Diagram(coordinateSystem(extent = {{-200, -100}, {200, 100}})),
   Documentation(info = "<html><head></head><body>
 <p>Model of a variable impedance load, whose value is specified by the reference values <code>PRefin</code> and <code>QRefIn</code> inputs and by the <code>URef</code> parameter.</p>

--- a/PowerGrids/Electrical/Loads/LoadPQVoltageDependenceInputs.mo
+++ b/PowerGrids/Electrical/Loads/LoadPQVoltageDependenceInputs.mo
@@ -15,7 +15,7 @@ model LoadPQVoltageDependenceInputs "Load model with voltage dependent P and Q s
   Modelica.Blocks.Interfaces.RealInput QRefIn(unit="var", displayUnit = "MVA") "Reactive reference power at VPu = 1, var" annotation(
     Placement(visible = true, transformation(origin = {-100, -44}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -100}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   annotation(
-    Icon(coordinateSystem(grid = {0.1, 0.1})),
+    Icon(coordinateSystem(grid = {0.1, 0.1}), graphics = {Rectangle(origin = {-79, -70}, extent = {{-1, 50}, {1, -50}}), Line(origin = {-45.9763, -70.2767}, points = {{-32, 0}, {26, 0}})}),
     Diagram(coordinateSystem(extent = {{-200, -100}, {200, 100}})),
   Documentation(info = "<html><head></head><body><p>Model of a PQ load with voltage dependence.</p>
 <p><code style=\"font-size: 12px;\">port.P = PRefIn*(port.U/URef)^alpha;</code><span style=\"font-size: 12px;\">&nbsp;</span><br style=\"font-size: 12px;\"><code style=\"font-size: 12px;\">port.Q = QRefIn*(port.U/URef)^beta;</code></p>

--- a/PowerGrids/Electrical/Machines/SynchronousMachine4WindingsInternalParameters.mo
+++ b/PowerGrids/Electrical/Machines/SynchronousMachine4WindingsInternalParameters.mo
@@ -1,15 +1,10 @@
 within PowerGrids.Electrical.Machines;
 
 model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 windings - internal parameters"
-  extends BaseClasses.OnePortACdqPU(
-    final generatorConvention = true,
-    localInit = if initOpt == InitializationOption.localSteadyStateFixedPowerFlow
-                then LocalInitializationOption.PV
-                else LocalInitializationOption.none);
+  extends BaseClasses.OnePortACdqPU(final generatorConvention = true, localInit = if initOpt == InitializationOption.localSteadyStateFixedPowerFlow then LocalInitializationOption.PV else LocalInitializationOption.none);
   extends Icons.Machine;
   import PowerGrids.Types.Choices.InitializationOption;
   import PowerGrids.Types.Choices.LocalInitializationOption;
-
   parameter Types.ActivePower PNom = SNom "Nominal active (turbine) power";
   parameter Types.PerUnit raPu "Armature resistance in p.u.";
   parameter Types.PerUnit LdPu "Direct axis stator leakage in p.u.";
@@ -27,21 +22,19 @@ model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 
   parameter Types.PerUnit rQ2Pu "Resistance of quadrature axis 2nd damper in p.u.";
   parameter Types.PerUnit DPu = 0 "Damping coefficient of the swing equation in p.u.";
   parameter SI.Time H "Kinetic constant = kinetic energy / rated power";
-  parameter Types.Choices.ExcitationPuType excitationPuType = 
-    PowerGrids.Types.Choices.ExcitationPuType.nominalStatorVoltageNoLoad "Choice of excitation base voltage";
+  parameter Types.Choices.ExcitationPuType excitationPuType = PowerGrids.Types.Choices.ExcitationPuType.nominalStatorVoltageNoLoad "Choice of excitation base voltage";
   parameter Boolean neglectTransformerTerms = true "Neglect the transformer terms in the Park equations";
   parameter Types.Choices.InitializationOption initOpt = systemPowerGrids.initOpt "Initialization option";
-  parameter Integer priority = integer(100 - 10*log10(PNom)) "Priority level used to select the machine to be used as frrequency reference (0=higher priority)" annotation(Evaluate = true);
+  parameter Integer priority = integer(100 - 10*log10(PNom)) "Priority level used to select the machine to be used as frrequency reference (0=higher priority)" annotation(
+    Evaluate = true);
   final parameter SI.AngularVelocity omegaBase = systemPowerGrids.omegaNom "Base angular frequency value";
   final parameter Types.PerUnit kuf(fixed = false) "Scaling factor for excitation p.u. voltage";
   constant Types.PerUnit omegaNomPu = 1 "Nominal frequency in p.u.";
-
   final parameter Types.PerUnit lambdadPuStart(fixed = false) "Start value of lambdadPu";
   final parameter Types.PerUnit lambdaqPuStart(fixed = false) "Start value of lambdaqPu";
   final parameter Types.PerUnit ufPuStart(fixed = false) "Start value of exciter voltage in p.u. (Kundur base)";
   final parameter Types.PerUnit ufPuInStart(fixed = false) "Start value of input exciter voltage in p.u. (user-selcted base";
   final parameter Types.PerUnit ifPuStart(fixed = false) "Start value of ifPu";
-    
   // Input variables
   Modelica.Blocks.Interfaces.RealInput PmPu(unit = "1") "Input mechanical power in p.u. (base PNom)" annotation(
     Placement(visible = true, transformation(origin = {-106, 46}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
@@ -49,12 +42,11 @@ model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 
     Placement(visible = true, transformation(origin = {-104, -50}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   // Output variables
   Modelica.Blocks.Interfaces.RealOutput omega(unit = "rad/s") "Angular frequency in rad/s" annotation(
-    Placement(visible = true, transformation(origin = {106, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {101, 59}, extent = {{-11, -11}, {11, 11}}, rotation = 0)));        
-// Other per-unit variables
+    Placement(visible = true, transformation(origin = {106, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {101, 59}, extent = {{-11, -11}, {11, 11}}, rotation = 0)));
+  // Other per-unit variables
   Modelica.Blocks.Interfaces.RealOutput omegaPu(start = 1) "Angular frequency in p.u." annotation(
     Placement(visible = true, transformation(origin = {106, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Types.PerUnit iDPu(start = 0) "Current of direct axis damper in p.u";
-  Types.PerUnit ifPu(start = ifPuStart) "Current of excitation winding in p.u.";
   Types.PerUnit iQ1Pu(start = 0) "Current of quadrature axis 1st damper in p.u.";
   Types.PerUnit iQ2Pu(start = 0) "Current of quadrature axis 2nd damper in p.u.";
   Types.PerUnit ufPu(start = ufPuStart) "Voltage of exciter winding in p.u. (base voltage as per Kundur)";
@@ -69,34 +61,34 @@ model SynchronousMachine4WindingsInternalParameters "Synchronous machine with 4 
   Types.PerUnit PePu(start = -PStart/SNom) "Electrical power in p.u. (base SNom)";
   Types.PerUnit PePuPNom = PePu*SNom/PNom "Electrical active power in p.u. (base PNom)";
   final Types.PerUnit omegaRefPu = terminalAC.omegaRefPu "Reference frequency in p.u.";
-
   // SI-unit variables
   Types.Frequency f = systemPowerGrids.fNom*omegaPu "Frequency of rotation of d-q axes";
   Modelica.Blocks.Interfaces.RealOutput VPu "Port voltage magnitude [pu]" annotation(
     Placement(visible = true, transformation(origin = {106, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Interfaces.RealOutput PPu "Active Power Production [pu base PNom]" annotation(
     Placement(visible = true, transformation(origin = {106, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput ifPu(start = ifPuStart) "Current of excitation winding in p.u." annotation(
+    Placement(visible = true, transformation(origin = {106, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, -100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 initial equation
-  // Scaling factor for excitation p.u. voltage
+// Scaling factor for excitation p.u. voltage
   if excitationPuType == Types.Choices.ExcitationPuType.Kundur then
     kuf = 1 "Choice of per-unit as per Kundur textbook";
   else
-    kuf = rfPu / MdPu "Base voltage gives 1 p.u. air-gap stator voltage at no load";
+    kuf = rfPu/MdPu "Base voltage gives 1 p.u. air-gap stator voltage at no load";
   end if;
-  // Equations to compute start values
-  // these equations are the same that involve the actual variables in the equation section
-  // except that they involve the start values instead, and they do not contain terms which
-  // are zero at steady state (e.g., all the damping winding currents)
-  // the Modelica tool figures out automatically how to solve them for the unknown parameters
+// Equations to compute start values
+// these equations are the same that involve the actual variables in the equation section
+// except that they involve the start values instead, and they do not contain terms which
+// are zero at steady state (e.g., all the damping winding currents)
+// the Modelica tool figures out automatically how to solve them for the unknown parameters
   udPuStart = raPu*idPuStart - omegaNomPu*lambdaqPuStart;
   uqPuStart = raPu*iqPuStart + omegaNomPu*lambdadPuStart;
   lambdadPuStart = (MdPu + LdPu)*idPuStart + MdPu*ifPuStart;
-  ufPuStart =  rfPu*ifPuStart;
+  ufPuStart = rfPu*ifPuStart;
   ufPuInStart = ufPuStart/kuf;
-
-  // Equations to determine the initial state values
+// Equations to determine the initial state values
   if initOpt == InitializationOption.noInit then
-    // No initial equations
+// No initial equations
   else
     omegaPu = omegaNomPu;
     der(omega) = 0;
@@ -110,49 +102,43 @@ initial equation
     der(lambdaQ2Pu) = 0;
   end if;
 equation
-  // Flux linkages
-  lambdadPu = (MdPu + LdPu) * idPu + MdPu * ifPu + MdPu * iDPu;
-  lambdafPu =     MdPu      *idPu + (MdPu + LfPu + mrcPu)*ifPu +    (MdPu + mrcPu)    *iDPu;
-  lambdaDPu =     MdPu      *idPu +     (MdPu + mrcPu)   *ifPu + (MdPu + LDPu + mrcPu)*iDPu;
-  lambdaqPu = (MqPu + LqPu) *iqPu +         MqPu         *iQ1Pu +        MqPu         *iQ2Pu;
-  lambdaQ1Pu =     MqPu     *iqPu +     (MqPu + LQ1Pu )  *iQ1Pu +        MqPu         *iQ2Pu;
-  lambdaQ2Pu =     MqPu     *iqPu +         MqPu         *iQ1Pu +    (MqPu + LQ2Pu)   *iQ2Pu;
-
-  // Equivalent circuit equations in Park's coordinates
+// Flux linkages
+  lambdadPu = (MdPu + LdPu)*idPu + MdPu*ifPu + MdPu*iDPu;
+  lambdafPu = MdPu*idPu + (MdPu + LfPu + mrcPu)*ifPu + (MdPu + mrcPu)*iDPu;
+  lambdaDPu = MdPu*idPu + (MdPu + mrcPu)*ifPu + (MdPu + LDPu + mrcPu)*iDPu;
+  lambdaqPu = (MqPu + LqPu)*iqPu + MqPu*iQ1Pu + MqPu*iQ2Pu;
+  lambdaQ1Pu = MqPu*iqPu + (MqPu + LQ1Pu)*iQ1Pu + MqPu*iQ2Pu;
+  lambdaQ2Pu = MqPu*iqPu + MqPu*iQ1Pu + (MqPu + LQ2Pu)*iQ2Pu;
+// Equivalent circuit equations in Park's coordinates
   if neglectTransformerTerms then
-    udPu = raPu * idPu - omegaPu * lambdaqPu;
-    uqPu = raPu * iqPu + omegaPu * lambdadPu;
+    udPu = raPu*idPu - omegaPu*lambdaqPu;
+    uqPu = raPu*iqPu + omegaPu*lambdadPu;
   else
-    udPu = raPu * idPu - omegaPu * lambdaqPu + der(lambdadPu) / omegaBase;
-    uqPu = raPu * iqPu + omegaPu * lambdadPu + der(lambdaqPu) / omegaBase;
-  end if;  
-  ufPu =  rfPu *ifPu  + der(lambdafPu)/omegaBase;
-  0    =  rDPu *iDPu  + der(lambdaDPu)/omegaBase;
-  0    =  rQ1Pu*iQ1Pu + der(lambdaQ1Pu)/omegaBase;
-  0    =  rQ2Pu*iQ2Pu + der(lambdaQ2Pu)/omegaBase;
-
-  // Mechanical equations
-  der(theta) = (omegaPu - omegaRefPu) * omegaBase;
+    udPu = raPu*idPu - omegaPu*lambdaqPu + der(lambdadPu)/omegaBase;
+    uqPu = raPu*iqPu + omegaPu*lambdadPu + der(lambdaqPu)/omegaBase;
+  end if;
+  ufPu = rfPu*ifPu + der(lambdafPu)/omegaBase;
+  0 = rDPu*iDPu + der(lambdaDPu)/omegaBase;
+  0 = rQ1Pu*iQ1Pu + der(lambdaQ1Pu)/omegaBase;
+  0 = rQ2Pu*iQ2Pu + der(lambdaQ2Pu)/omegaBase;
+// Mechanical equations
+  der(theta) = (omegaPu - omegaRefPu)*omegaBase;
   2*H*der(omegaPu) = (CmPu*PNom/SNom - CePu) - DPu*(omegaPu - omegaRefPu);
   CePu = lambdaqPu*idPu - lambdadPu*iqPu;
   PePu = CePu*omegaPu;
   PmPu = CmPu*omegaPu;
   omega = omegaPu*omegaBase;
-
-  // Excitation voltage p.u. conversion
-  ufPu = ufPuIn * kuf;
-
-  // Output signal equations
+// Excitation voltage p.u. conversion
+  ufPu = ufPuIn*kuf;
+// Output signal equations
   VPu = port.VPu;
   PPu = -port.P/PNom;
-  
-  // Overconstrained connector
+// Overconstrained connector
   Connections.potentialRoot(terminalAC.omegaRefPu, integer(priority));
   if Connections.isRoot(terminalAC.omegaRefPu) then
-     terminalAC.omegaRefPu = omegaPu;
+    terminalAC.omegaRefPu = omegaPu;
   end if;
-  
-annotation(
+  annotation(
     Documentation(info = "<html><head></head><body><p>Model of a sychronous machine with four windings. The transformer voltage terms are neglected if <code>neglectTransformerTerms=true</code>. The model parameters refer directly to internal physical parameters such as inductances and resistances.</p>
 <p>The model is taken from the theory manual of the Eurostag software. For consistency with the base class <a href=\"modelica://PowerGrids.Electrical.BaseClasses.OnePortACdq\">OnePortACdq</a>, however, the currents ifPu, idPu and iqPu are all assumed to be positive entering, while the Eurostag manual assumes them to be all positive leaving. Therefore, all the current and fluxes have an opposite sign in the Park equations.</p>
 <p>This model is in fact equivalent to the model described in Kundur, Power Systems Stability and Control, Chapter 3, except for the current sign conventions, which in that case are assumed to be positive entering for the rotor winding and positive leaving for the direct and quadrature stator axes. The correspondance of the parameter symbols is given in the table, all parameters are in p.u. referred to the machine rated values.</p>
@@ -177,5 +163,6 @@ annotation(
 <li><code>Types.ExcitationPuType.nominalStatorVoltageNoLoad</code>: 1 p.u. of excitation voltage gives 1 p.u. of air-gap stator voltage at no-load conditions</li>
 <li><code>Types.ExcitationPuType.Kundur</code>: base voltage as in Kundur, Power Systems Stability and Control, Chapter 3. Note that in this case, typical p.u. values are less than 0.001</li>
 </ul>
-</body></html>"));
+</body></html>"),
+    Icon(graphics = {Rectangle(origin = {-79, 0}, extent = {{-1, 60}, {1, -60}}), Line(origin = {-69, 0}, points = {{-9, 0}, {9, 0}}), Rectangle(origin = {-79, 0}, extent = {{-1, 60}, {1, -60}}), Rectangle(origin = {81, -20}, extent = {{-1, 90}, {1, -90}}), Line(origin = {70, 0}, points = {{-10, 0}, {10, 0}}), Line(origin = {86, 60}, points = {{-4, 0}, {4, 0}}), Line(origin = {86, -100}, points = {{-4, 0}, {4, 0}}), Line(origin = {86, -60}, points = {{-4, 0}, {4, 0}}), Line(origin = {86, -20}, points = {{-4, 0}, {4, 0}}), Line(origin = {86, 20}, points = {{-4, 0}, {4, 0}})}));
 end SynchronousMachine4WindingsInternalParameters;

--- a/PowerGrids/Electrical/Test/SynchronousMachine4Windings.mo
+++ b/PowerGrids/Electrical/Test/SynchronousMachine4Windings.mo
@@ -13,12 +13,12 @@ model SynchronousMachine4Windings
   Modelica.Blocks.Sources.Step ufPu(height = 0, offset = 0.000939) annotation(
     Placement(visible = true, transformation(origin = {-50, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(bus.terminalAC, machine.terminalAC) annotation(
-    Line(points = {{0, 20}, {0, 0}}));
   connect(ufPu.y, machine.ufPuIn) annotation(
     Line(points = {{-38, -30}, {-24, -30}, {-24, -14}, {-10, -14}, {-10, -14}}, color = {0, 0, 127}));
   connect(PmPu.y, machine.PmPu) annotation(
     Line(points = {{-38, 10}, {-24, 10}, {-24, -6}, {-10, -6}, {-10, -6}}, color = {0, 0, 127}));
+  connect(bus.terminalAC, machine.terminalAC) annotation(
+    Line(points = {{0, 20}, {0, -10}}));
   annotation(
     experiment(StartTime = 0, StopTime = 40, Tolerance = 1e-06, Interval = 0.02),
     Documentation(info = "<html><head></head><body><p>Test case for the conversion of external parameter to internal parameters taken from Kundur, Power System Stability and Control, example 4.1. Note that the system frequency for this example is 60 Hz.</p>

--- a/PowerGrids/Electrical/Test/SynchronousMachine4WindingsAccurate.mo
+++ b/PowerGrids/Electrical/Test/SynchronousMachine4WindingsAccurate.mo
@@ -13,12 +13,12 @@ model SynchronousMachine4WindingsAccurate
   Modelica.Blocks.Sources.Step ufPu(height = 0, offset = 0.000939) annotation(
     Placement(visible = true, transformation(origin = {-50, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(bus.terminalAC, machine.terminalAC) annotation(
-    Line(points = {{0, 20}, {0, 0}}));
   connect(ufPu.y, machine.ufPuIn) annotation(
     Line(points = {{-38, -30}, {-24, -30}, {-24, -14}, {-10, -14}, {-10, -14}}, color = {0, 0, 127}));
   connect(PmPu.y, machine.PmPu) annotation(
     Line(points = {{-38, 10}, {-24, 10}, {-24, -6}, {-10, -6}, {-10, -6}}, color = {0, 0, 127}));
+  connect(bus.terminalAC, machine.terminalAC) annotation(
+    Line(points = {{0, 20}, {0, -10}}));
   annotation(
     experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-06, Interval = 0.002),
     __OpenModelica_simulationFlags(homotopyOnFirstTry = "()"),

--- a/PowerGrids/Electrical/Test/SynchronousMachine4WindingsExact.mo
+++ b/PowerGrids/Electrical/Test/SynchronousMachine4WindingsExact.mo
@@ -13,12 +13,12 @@ model SynchronousMachine4WindingsExact
   Modelica.Blocks.Sources.Step ufPu(height = 0, offset = 0.000939) annotation(
     Placement(visible = true, transformation(origin = {-50, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(bus.terminalAC, machine.terminalAC) annotation(
-    Line(points = {{0, 20}, {0, 0}}));
   connect(ufPu.y, machine.ufPuIn) annotation(
     Line(points = {{-38, -30}, {-24, -30}, {-24, -14}, {-10, -14}, {-10, -14}}, color = {0, 0, 127}));
   connect(PmPu.y, machine.PmPu) annotation(
     Line(points = {{-38, 10}, {-24, 10}, {-24, -6}, {-10, -6}, {-10, -6}}, color = {0, 0, 127}));
+  connect(bus.terminalAC, machine.terminalAC) annotation(
+    Line(points = {{0, 20}, {0, -10}}));
   annotation(
     experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-06, Interval = 0.002),
     __OpenModelica_simulationFlags(homotopyOnFirstTry = "()"),

--- a/PowerGrids/Electrical/Test/SynchronousMachine4WindingsNoLoad.mo
+++ b/PowerGrids/Electrical/Test/SynchronousMachine4WindingsNoLoad.mo
@@ -13,12 +13,12 @@ model SynchronousMachine4WindingsNoLoad
   Modelica.Blocks.Sources.Step ufPu(height = 0, offset = 1) annotation(
     Placement(visible = true, transformation(origin = {-50, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(bus.terminalAC, machine.terminalAC) annotation(
-    Line(points = {{0, 20}, {0, 0}}));
   connect(ufPu.y, machine.ufPuIn) annotation(
     Line(points = {{-38, -30}, {-24, -30}, {-24, -14}, {-10, -14}, {-10, -14}}, color = {0, 0, 127}));
   connect(PmPu.y, machine.PmPu) annotation(
     Line(points = {{-38, 10}, {-24, 10}, {-24, -6}, {-10, -6}, {-10, -6}}, color = {0, 0, 127}));
+  connect(bus.terminalAC, machine.terminalAC) annotation(
+    Line(points = {{0, 20}, {0, -10}}));
   annotation(
     experiment(StartTime = 0, StopTime = 200, Tolerance = 1e-06, Interval = 0.02),
     Documentation(info = "<html><head></head><body><p>This test case validates the NoLoad choice of base excitation voltage of the SynchronousMachine4Windings model.</p>

--- a/PowerGrids/Electrical/Test/SynchronousMachine4WindingsNoLoadAccurate.mo
+++ b/PowerGrids/Electrical/Test/SynchronousMachine4WindingsNoLoadAccurate.mo
@@ -13,12 +13,12 @@ model SynchronousMachine4WindingsNoLoadAccurate
   Modelica.Blocks.Sources.Step ufPu(height = 0, offset = 1) annotation(
     Placement(visible = true, transformation(origin = {-50, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(bus.terminalAC, machine.terminalAC) annotation(
-    Line(points = {{0, 20}, {0, 0}}));
   connect(ufPu.y, machine.ufPuIn) annotation(
     Line(points = {{-38, -30}, {-24, -30}, {-24, -14}, {-10, -14}, {-10, -14}}, color = {0, 0, 127}));
   connect(PmPu.y, machine.PmPu) annotation(
     Line(points = {{-38, 10}, {-24, 10}, {-24, -6}, {-10, -6}, {-10, -6}}, color = {0, 0, 127}));
+  connect(bus.terminalAC, machine.terminalAC) annotation(
+    Line(points = {{0, 20}, {0, -10}}));
   annotation(
     experiment(StartTime = 0, StopTime = 200, Tolerance = 1e-06, Interval = 0.02),
     __OpenModelica_simulationFlags(homotopyOnFirstTry = "()"),

--- a/PowerGrids/Electrical/Test/SynchronousMachine4WindingsNoLoadExact.mo
+++ b/PowerGrids/Electrical/Test/SynchronousMachine4WindingsNoLoadExact.mo
@@ -13,12 +13,12 @@ model SynchronousMachine4WindingsNoLoadExact
   Modelica.Blocks.Sources.Step ufPu(height = 0, offset = 1) annotation(
     Placement(visible = true, transformation(origin = {-50, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
-  connect(bus.terminalAC, machine.terminalAC) annotation(
-    Line(points = {{0, 20}, {0, 0}}));
   connect(ufPu.y, machine.ufPuIn) annotation(
     Line(points = {{-38, -30}, {-24, -30}, {-24, -14}, {-10, -14}, {-10, -14}}, color = {0, 0, 127}));
   connect(PmPu.y, machine.PmPu) annotation(
     Line(points = {{-38, 10}, {-24, 10}, {-24, -6}, {-10, -6}, {-10, -6}}, color = {0, 0, 127}));
+  connect(bus.terminalAC, machine.terminalAC) annotation(
+    Line(points = {{0, 20}, {0, -10}}));
   annotation(
     experiment(StartTime = 0, StopTime = 200, Tolerance = 1e-06, Interval = 0.02),
     __OpenModelica_simulationFlags(homotopyOnFirstTry = "()"),


### PR DESCRIPTION
This PR substitutes the PR #19 with some little differencies:

- the new output for ifPu maintains the original name of the variable (i.e., ifPu)
- the new icon is different from the one designed in the PR #19, the chosen style is better extendible to other components
- the old terminals are left in te same position, in order to avoid graphically broken wires in the already built diagrams