### PR TITLE
Fixed wrong UNom and SNom modifiers, examples updated accordingly

### DIFF
--- a/PowerGrids/Examples/Tutorial/GridOperation/Controlled/ControlledGenerator.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Controlled/ControlledGenerator.mo
@@ -7,7 +7,7 @@ model ControlledGenerator "Model of a synchronous generator with governor, AVR, 
   parameter Boolean showDataOnDiagramsPu = systemPowerGrids.showDataOnDiagramsPu "=true, P,Q,V and phase are shown on the diagrams in per-unit (it overrides the SI format)";
   parameter Boolean showDataOnDiagramsSI = systemPowerGrids.showDataOnDiagramsSI "=true, P,Q,V and phase are shown on the diagrams in multiple of SI (kV, MW, Mvar)";
   parameter Integer dataOnDiagramDigits = systemPowerGrids.dataOnDiagramDigits "number of digits for data on diagrams";  
-  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08, SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8) annotation(
+  PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PStart = -4.75e+08, QStart = -1.56e+08, SNom = SNom, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = UNom, portVariablesPhases = true, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8) annotation(
     Placement(transformation(origin = {40, 0}, extent = {{-10, 10}, {10, -10}}, rotation = -0)));
   PowerGrids.Electrical.Controls.TurbineGovernors.IEEE_TGOV1 TGOV(PMechPuStart = -GEN.PStart/GEN.SNom, R = 0.05, T1 = 0.5, T2 = 3, T3 = 10, VMax = 1) annotation(
     Placement(visible = true, transformation(origin = {4, 28}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));

--- a/PowerGrids/Examples/Tutorial/GridOperation/Controlled/ControlledGridWithControlledGen.mo
+++ b/PowerGrids/Examples/Tutorial/GridOperation/Controlled/ControlledGridWithControlledGen.mo
@@ -11,7 +11,7 @@ model ControlledGridWithControlledGen "System under automatic control with high-
     Placement(visible = true, transformation(origin = {56, 10}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05 * 380e3, portVariablesPhases = true)  annotation(
     Placement(visible = true, transformation(origin = {56, -12}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Examples.Tutorial.GridOperation.Controlled.ControlledGenerator ctrlGEN(AVR(Ka = 150)) annotation(
+  PowerGrids.Examples.Tutorial.GridOperation.Controlled.ControlledGenerator ctrlGEN(UNom = 21000, SNom = 5e+08, AVR(Ka = 150)) annotation(
     Placement(transformation(origin = {-64, 0}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
   Electrical.Faults.ThreePhaseFault FAULT(R = 0.05,SNom = 5e+08, UNom = 380000, portVariablesPhases = true, startTime = 2, stopTime = 2.1) annotation(
     Placement(visible = true, transformation(origin = {74, -12}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/PowerGrids/Examples/Tutorial/IslandOperation/TwoGeneratorsOneReferenceGenerator.mo
+++ b/PowerGrids/Examples/Tutorial/IslandOperation/TwoGeneratorsOneReferenceGenerator.mo
@@ -12,11 +12,11 @@ model TwoGeneratorsOneReferenceGenerator
     Placement(visible = true, transformation(origin = {-50, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN2( R = 0.15e-2 * 419 ^ 2 / 500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2 * 419 ^ 2 / 500, portVariablesPhases = true, rFixed = 419 / 21) annotation(
     Placement(visible = true, transformation(origin = {70, 20}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
-  PowerGrids.Examples.Tutorial.GridOperation.Controlled.ControlledGenerator GEN1(GEN(UNom = 21e3, SNom = 500e6, PStart = -450.88e6, QStart = -294.351e6), TGOV(R = 0.05)) annotation(
+  PowerGrids.Examples.Tutorial.GridOperation.Controlled.ControlledGenerator GEN1(UNom = 21e3, SNom = 500e6, GEN(PStart = -450.88e6, QStart = -294.351e6), TGOV(R = 0.05)) annotation(
     Placement(visible = true, transformation(origin = {-104, 6}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Branches.LineConstantImpedance LINE( R = 10, SNom = 5e+8, UNom = 380000, X = 100, portVariablesPhases = true) annotation(
     Placement(visible = true, transformation(origin = {10, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Examples.Tutorial.GridOperation.Controlled.ControlledGenerator GEN2(GEN(UNom = 21e3, SNom = 500e6, PStart = -450.88e6, QStart = -294.351e6), TGOV(R = 0.05)) annotation(
+  PowerGrids.Examples.Tutorial.GridOperation.Controlled.ControlledGenerator GEN2(UNom = 21e3, SNom = 500e6, GEN(PStart = -450.88e6, QStart = -294.351e6), TGOV(R = 0.05)) annotation(
     Placement(visible = true, transformation(origin = {120, 8}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Buses.Bus NTHV2(UNom = 380000, portVariablesPhases = true) annotation(
     Placement(visible = true, transformation(origin = {40, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));


### PR DESCRIPTION
this PR fixes the wrong modifiers of SNom and UNom in the model PowerGrids.Examples.Tutorial.GridOperation.Controlled.ControlledGenerator.

The examples wich use said ControlldGenerator have been updated accordingly
