### PR TITLE
Changed initial equation so the synchronous machine model is index 1

### DIFF
--- a/PowerGrids/Electrical/Machines/SynchronousMachine4WindingsInternalParameters.mo
+++ b/PowerGrids/Electrical/Machines/SynchronousMachine4WindingsInternalParameters.mo
@@ -98,7 +98,7 @@ initial equation
     // No initial equations
   else
     omegaPu = omegaNomPu;
-    der(omega) = 0;
+    der(omegaPu) = 0;
     if not neglectTransformerTerms then
       der(lambdadPu) = 0;
       der(lambdaqPu) = 0;


### PR DESCRIPTION
This allows the new OMC backend and the MARCO compiler to handle the synchronous machine model without worrying about index reduction.