### PR TITLE
Workaround to force the computation of the EPF

### DIFF
--- a/PowerGrids/Electrical/BaseClasses/OnePortACPF.mo
+++ b/PowerGrids/Electrical/BaseClasses/OnePortACPF.mo
@@ -5,6 +5,19 @@ partial model OnePortACPF
     redeclare replaceable connector TerminalAC = PowerGrids.Interfaces.TerminalACPF);
   Boolean isSlackBus = false "=true, if the componentsPF is a slack bus";
   final Modelica.Blocks.Interfaces.BooleanOutput isSlackBusOut = isSlackBus "output connector to propagate the value of the flag isSlackBus";
+
+protected
+  // The following parameter and variables are used as workaround to force the computation of
+  // the Embedded Power Flow before to start the initialization, in order to proper compute the start
+  // values of the initialization itself.
+  // This workaround in necessary because some Modelica compilers does not correctly implement the dependency
+  // introduced by the start attributes (see Modelica Specificatoin - section 8.6).
+  parameter Real zero = 0 annotation(Evaluate=false, HideResult=true);
+  final Real Pepf = PStart;
+  final Real Qepf = QStart;
+  final Real Uepf = UStart;
+  final Real UPhepf = UPhaseStart;
+
 initial equation
   UStartPF = UNom;
   UPhaseStartPF = 0;
@@ -12,8 +25,8 @@ initial equation
   QStartPF = 0;
 
 equation
-  port.v = terminalAC.v;
-  port.i = terminalAC.i;
+  port.v = terminalAC.v + zero*Complex(Pepf+Qepf+Uepf+UPhepf) "the part multiplied by zero is to force the EPF computation before to start the initialization";
+  port.i = terminalAC.i + zero*Complex(Pepf+Qepf+Uepf+UPhepf) "the part multiplied by zero is to force the EPF computation before to start the initialization";
 annotation(
     Documentation(info = "<html>
 <p>This is the base class for all the PF components with an AC terminal.</p>

--- a/PowerGrids/Electrical/BaseClasses/TwoPortACPF.mo
+++ b/PowerGrids/Electrical/BaseClasses/TwoPortACPF.mo
@@ -4,6 +4,23 @@ partial model TwoPortACPF
   extends TwoPortACVI(
     redeclare replaceable connector TerminalAC_a = PowerGrids.Interfaces.TerminalACPF_a,
     redeclare replaceable connector TerminalAC_b = PowerGrids.Interfaces.TerminalACPF_b);
+
+protected
+  // The following parameter and variables are used as workaround to force the computation of
+  // the Embedded Power Flow before to start the initialization, in order to proper compute the start
+  // values of the initialization itself.
+  // This workaround in necessary because some Modelica compilers does not implement the dependency
+  // introduced by the start attributes (see Modelica Specificatoin - section 8.6).
+  parameter Real zero = 0 annotation(Evaluate=false, HideResult=true);
+  final Real PepfA = PStartA;
+  final Real QepfA = QStartA;
+  final Real UepfA = UStartA;
+  final Real UPhepfA = UPhaseStartA;
+  final Real PepfB = PStartB;
+  final Real QepfB = QStartB;
+  final Real UepfB = UStartB;
+  final Real UPhepfB = UPhaseStartB;
+
 initial equation
   UStartAPF = UNomA;
   UPhaseStartAPF = 0;
@@ -14,10 +31,10 @@ initial equation
   PStartBPF = 0;
   QStartBPF = 0;
   equation
-    portA.v = terminalAC_a.v;
-    portB.v = terminalAC_b.v;
-    portA.i = terminalAC_a.i;
-    portB.i = terminalAC_b.i;
+    portA.v = terminalAC_a.v + zero*Complex(PepfA+QepfA+UepfA+UPhepfA) "the part multiplied by zero is to force the EPF computation before to start the initialization";
+    portB.v = terminalAC_b.v + zero*Complex(PepfB+QepfB+UepfB+UPhepfB) "the part multiplied by zero is to force the EPF computation before to start the initialization";
+    portA.i = terminalAC_a.i + zero*Complex(PepfA+QepfA+UepfA+UPhepfA) "the part multiplied by zero is to force the EPF computation before to start the initialization";
+    portB.i = terminalAC_b.i + zero*Complex(PepfB+QepfB+UepfB+UPhepfB) "the part multiplied by zero is to force the EPF computation before to start the initialization";
   annotation(
     Documentation(info = "<html>
 <p>This is the base class for all the PW components with two AC terminals.</p>


### PR DESCRIPTION
This PR implements a workaround to force the computation of the Embedded Power Flow before to start the initialization, in order to proper compute the start values of the initialization itself.
This workaround in necessary because some Modelica compilers does not correctly implement the dependency introduced by the start attributes (see Modelica Specificatoin - section 8.6).