### PR TITLE
Cosmetic changes; adds literal constant U in PV nodes

### DIFF
--- a/PowerGrids/Electrical/Controls/TurbineGovernors/IEEE_TGOV1.mo
+++ b/PowerGrids/Electrical/Controls/TurbineGovernors/IEEE_TGOV1.mo
@@ -1,7 +1,7 @@
 within PowerGrids.Electrical.Controls.TurbineGovernors;
+
 block IEEE_TGOV1 "Simple Steam Turbine Governor - IEEE type TGOV1"
   extends Controls.BaseClasses.BaseControllerFramework;
-
   parameter SI.PerUnit VMax = 1 "Maximum gate limit in p.u.";
   parameter SI.PerUnit VMin = 0 "Minimum gate limit in p.u.";
   parameter SI.PerUnit R = 0.05 "Controller Droop";
@@ -9,34 +9,35 @@ block IEEE_TGOV1 "Simple Steam Turbine Governor - IEEE type TGOV1"
   parameter SI.Time T1 = 0.5 "Governor time constant";
   parameter SI.Time T2 = 3 "Turbine derivative time constant";
   parameter SI.Time T3 = 10 "Turbine delay time constant";
-  parameter SI.PerUnit PMechPuStart = 1 "Required start value of PmechPu when fixInitialControlledVariable = true" annotation(Dialog(enable = fixInitialControlledVariable));
-  parameter SI.PerUnit oversaturationPu = 0.1 "abs(u-usat)/(Vmax-Vmin) in case of saturated initial condition" annotation(Dialog(enable = fixInitialControlledVariable));
+  parameter SI.PerUnit PMechPuStart = 1 "Required start value of PmechPu when fixInitialControlledVariable = true" annotation(
+    Dialog(enable = fixInitialControlledVariable));
+  parameter SI.PerUnit oversaturationPu = 0.1 "abs(u-usat)/(Vmax-Vmin) in case of saturated initial condition" annotation(
+    Dialog(enable = fixInitialControlledVariable));
   final parameter Real delta = (firstOrderLim.yMax - firstOrderLim.yMin)*oversaturationPu "Actuator saturation margin";
-
   Modelica.Blocks.Interfaces.RealInput RefLPu "Reference frequency/load input [pu]" annotation(
-    Placement(visible = true, transformation(origin = {-140, 50}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, 40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+    Placement(transformation(origin = {-138, 50}, extent = {{-20, -20}, {20, 20}}), iconTransformation(origin = {-102, 40}, extent = {{-20, -20}, {20, 20}})));
   Modelica.Blocks.Interfaces.RealInput omegaPu "Frequency [pu]" annotation(
-    Placement(visible = true, transformation(origin = {-140, -30}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-100, -40}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+    Placement(transformation(origin = {-138, 0}, extent = {{-20, -20}, {20, 20}}), iconTransformation(origin = {-102, -40}, extent = {{-20, -20}, {20, 20}})));
   Modelica.Blocks.Interfaces.RealOutput PMechPu "Mechanical turbine power [pu]" annotation(
-    Placement(visible = true, transformation(origin = {130,50}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, 3.55271e-15}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+    Placement(transformation(origin = {130, 50}, extent = {{-10, -10}, {10, 10}}), iconTransformation(origin = {120, 3.55271e-15}, extent = {{-20, -20}, {20, 20}})));
   Modelica.Blocks.Math.Feedback errPu annotation(
     Placement(visible = true, transformation(origin = {-70, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback deltaOmegaPu annotation(
-    Placement(visible = true, transformation(origin = {-90, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Sources.Constant omegaRefPu(k = 1)  annotation(
-    Placement(visible = true, transformation(origin = {-90, -70}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Math.Gain gainDt(k = Dt)  annotation(
-    Placement(visible = true, transformation(origin = {10, -30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Math.Gain gainDivR(k = 1 / R)  annotation(
+    Placement(transformation(origin = {-90, 0}, extent = {{-10, -10}, {10, 10}})));
+  Modelica.Blocks.Sources.Constant omegaRefPu(k = 1) annotation(
+    Placement(transformation(origin = {-90, -34}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+  Modelica.Blocks.Math.Gain gainDt(k = Dt) annotation(
+    Placement(transformation(origin = {10, 0}, extent = {{-10, -10}, {10, 10}})));
+  Modelica.Blocks.Math.Gain gainDivR(k = 1/R) annotation(
     Placement(visible = true, transformation(origin = {-30, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Controls.FirstOrderWithNonWindupLimiter firstOrderLim(T = T1, initType = Modelica.Blocks.Types.Init.SteadyState, k = 1, yMax = VMax, yMin = VMin)  annotation(
+  PowerGrids.Controls.FirstOrderWithNonWindupLimiter firstOrderLim(T = T1, initType = Modelica.Blocks.Types.Init.SteadyState, k = 1, yMax = VMax, yMin = VMin) annotation(
     Placement(visible = true, transformation(origin = {10, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  PowerGrids.Controls.LeadLag leadLag(T1 = T2, T2 = T3, initType = Modelica.Blocks.Types.Init.SteadyState, k = 1)  annotation(
+  PowerGrids.Controls.LeadLag leadLag(T1 = T2, T2 = T3, initType = Modelica.Blocks.Types.Init.SteadyState, k = 1) annotation(
     Placement(visible = true, transformation(origin = {50, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback sumPMechPu annotation(
     Placement(visible = true, transformation(origin = {90, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 initial equation
-  /* The following equation could be written as
+/* The following equation could be written as
  
     if fixInitialControlledVariable then
       if firstOrderLim.u > firstOrderLim.yMax then
@@ -53,21 +54,17 @@ initial equation
       variables. This is only possible by writing those equations in implicit form
   */
   if fixInitialControlledVariable then
-    0 = homotopy(
-      actual = if firstOrderLim.u > firstOrderLim.yMax then firstOrderLim.u - (firstOrderLim.yMax + delta)
-               else if firstOrderLim.u < firstOrderLim.yMin then firstOrderLim.u - (firstOrderLim.yMin - delta)
-               else PMechPu - PMechPuStart,
-      simplified = PMechPu - PMechPuStart);
+    0 = homotopy(actual = if firstOrderLim.u > firstOrderLim.yMax then firstOrderLim.u - (firstOrderLim.yMax + delta) else if firstOrderLim.u < firstOrderLim.yMin then firstOrderLim.u - (firstOrderLim.yMin - delta) else PMechPu - PMechPuStart, simplified = PMechPu - PMechPuStart);
   end if;
 equation
   connect(omegaRefPu.y, deltaOmegaPu.u2) annotation(
-    Line(points = {{-90, -58}, {-90, -58}, {-90, -38}, {-90, -38}}, color = {0, 0, 127}));
+    Line(points = {{-90, -23}, {-90, -8}}, color = {0, 0, 127}));
   connect(gainDt.y, sumPMechPu.u2) annotation(
-    Line(points = {{22, -30}, {90, -30}, {90, 42}, {90, 42}}, color = {0, 0, 127}));
+    Line(points = {{21, 0}, {90, 0}, {90, 42}}, color = {0, 0, 127}));
   connect(deltaOmegaPu.y, gainDt.u) annotation(
-    Line(points = {{-80, -30}, {-2, -30}, {-2, -30}, {-2, -30}}, color = {0, 0, 127}));
+    Line(points = {{-81, 0}, {-3, 0}, {-3, 0}, {-3, 0}}, color = {0, 0, 127}));
   connect(deltaOmegaPu.y, errPu.u2) annotation(
-    Line(points = {{-80, -30}, {-70, -30}, {-70, 42}, {-70, 42}}, color = {0, 0, 127}));
+    Line(points = {{-81, 0}, {-70, 0}, {-70, 42}}, color = {0, 0, 127}));
   connect(sumPMechPu.y, PMechPu) annotation(
     Line(points = {{99, 50}, {121, 50}, {121, 50}, {129, 50}}, color = {0, 0, 127}));
   connect(leadLag.y, sumPMechPu.u1) annotation(
@@ -79,13 +76,13 @@ equation
   connect(errPu.y, gainDivR.u) annotation(
     Line(points = {{-61, 50}, {-43, 50}, {-43, 50}, {-43, 50}}, color = {0, 0, 127}));
   connect(RefLPu, errPu.u1) annotation(
-    Line(points = {{-140, 50}, {-78, 50}}, color = {0, 0, 127}));
+    Line(points = {{-138, 50}, {-78, 50}}, color = {0, 0, 127}));
   connect(omegaPu, deltaOmegaPu.u1) annotation(
-    Line(points = {{-140, -30}, {-100, -30}, {-100, -30}, {-98, -30}}, color = {0, 0, 127}));
+    Line(points = {{-138, 0}, {-98, 0}}, color = {0, 0, 127}));
   annotation(
     Icon(coordinateSystem(grid = {0.1, 0.1}, initialScale = 0.1), graphics = {Rectangle(origin = {-1, -1}, fillColor = {255, 255, 255}, fillPattern = FillPattern.Solid, extent = {{-99, 101}, {101, -99}}), Text(origin = {49, -25}, extent = {{-127, 27}, {33, -49}}, textString = "TGOV1"), Text(origin = {0, 120}, textColor = {0, 0, 255}, extent = {{-80, 12}, {80, -12}}, textString = "%name"), Text(origin = {-6, 46}, extent = {{-60, 26}, {70, -40}}, textString = "IEEE")}),
-    Diagram(coordinateSystem(extent = {{-200, -100}, {200, 100}})),
-  Documentation(info = "<html>
+    Diagram(coordinateSystem(extent = {{-160, 80}, {140, -60}})),
+    Documentation(info = "<html>
 <p>The class implements a model of a simple steam turbine governor according to the IEEE technical report PES-TR1 Jan 2013.</p>
 <p>The type implemented is the TGOV1, described in the chapter 2.2 of the same IEEE technical report PES-TR1 Jan 2013.</p>
 <p>If <code>fixInitialControlledVariable = true</code>, an initial equation is added to ensure that the mechanical power output <code>PMechPu</code> is equal to its start value <code>PMechPuStart</code>. In order to fulfill this condition, the initial value of the reference signal should be free, so that the Modelica tool can back-compute it automatically. For this purpose, the <a href=\"modelica://PowerGrids.Controls.FreeOffset\">PowerGrids.Controls.FreeOffset</a> block should be used to generate the reference signal to be connected to the <code>VrefPu</code> input.</p>

--- a/PowerGrids/Examples/ENTSOE/PowerFlow.mo
+++ b/PowerGrids/Examples/ENTSOE/PowerFlow.mo
@@ -4,7 +4,7 @@ model PowerFlow
   extends Modelica.Icons.Example;
   inner Electrical.System systemPowerGrids annotation(
     Placement(transformation(origin = {50, 30}, extent = {{-10, -10}, {10, 10}})));
-  PowerGrids.Electrical.PowerFlow.PVBus GEN(UNom = 21000, SNom = 500000000, P = -475000000)  annotation(
+  PowerGrids.Electrical.PowerFlow.PVBus GEN(UNom = 21000, SNom = 500000000, P = -475000000, U = 21000)  annotation(
     Placement(transformation(origin = {-30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 180)));
   PowerGrids.Electrical.PowerFlow.BusPF NTLV(UNom = 21000)  annotation(
     Placement(transformation(origin = {0, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));

--- a/PowerGrids/Examples/ENTSOE/PowerFlow.mo
+++ b/PowerGrids/Examples/ENTSOE/PowerFlow.mo
@@ -25,5 +25,5 @@ model PowerFlow
 annotation(
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing",
     experiment(StopTime = 1),
-    Diagram(coordinateSystem(extent = {{-40, 60}, {80, -60}})));
+    Diagram(coordinateSystem(extent = {{-40, 40}, {80, -60}})));
 end PowerFlow;

--- a/PowerGrids/Examples/ENTSOE/PowerFlow.mo
+++ b/PowerGrids/Examples/ENTSOE/PowerFlow.mo
@@ -4,15 +4,15 @@ model PowerFlow
   extends Modelica.Icons.Example;
   inner Electrical.System systemPowerGrids annotation(
     Placement(transformation(origin = {50, 30}, extent = {{-10, -10}, {10, 10}})));
-  PowerGrids.Electrical.PowerFlow.PVBus GEN(UNom = 21000, SNom = 500000000, P = -475000000, U = 21000)  annotation(
+  PowerGrids.Electrical.PowerFlow.PVBus GEN(UNom = 21000, SNom = 500e6, P = -475e6, U = 21000)  annotation(
     Placement(transformation(origin = {-30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 180)));
   PowerGrids.Electrical.PowerFlow.BusPF NTLV(UNom = 21000)  annotation(
     Placement(transformation(origin = {0, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Electrical.PowerFlow.TransformerFixedRatioPF TGEN(UNomA = 21000, UNomB = 419000, SNom = 500000000, rFixed = 419/21, R = 0.15e-2*419^2/500, X = 16e-2*419^2/500)  annotation(
+  Electrical.PowerFlow.TransformerFixedRatioPF TGEN(UNomA = 21000, UNomB = 419000, SNom = 500e6, rFixed = 419/21, R = 0.15e-2*419^2/500, X = 16e-2*419^2/500)  annotation(
     Placement(transformation(origin = {20, -20}, extent = {{-10, -10}, {10, 10}})));
-  Electrical.PowerFlow.SlackBus GRID(UNom = 380000, SNom = 500000000, U = 1.05*380e3)  annotation(
+  Electrical.PowerFlow.SlackBus GRID(UNom = 380000, SNom = 500e6, U = 1.05*380e3)  annotation(
     Placement(transformation(origin = {50, 0}, extent = {{-10, -10}, {10, 10}})));
-  Electrical.PowerFlow.PQBus GRIDL(UNom = 380000, SNom = 500000000, P = 475000000, Q = 76000000)  annotation(
+  Electrical.PowerFlow.PQBus GRIDL(UNom = 380000, SNom = 500e6, P = 475e6, Q = 76e6)  annotation(
     Placement(transformation(origin = {50, -30}, extent = {{-10, -10}, {10, 10}})));equation
   connect(GEN.terminalAC, NTLV.terminalAC) annotation(
     Line(points = {{-30, 0}, {-30, -20}, {0, -20}}));

--- a/PowerGrids/Examples/ENTSOE/SteadyState.mo
+++ b/PowerGrids/Examples/ENTSOE/SteadyState.mo
@@ -3,13 +3,13 @@ within PowerGrids.Examples.ENTSOE;
 model SteadyState "Reproduces the basic static power flow, see fig. 3-1 of the report"
   extends Modelica.Icons.Example;
   inner PowerGrids.Electrical.System systemPowerGrids annotation(
-    Placement(transformation(origin = {90, 50}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {42, 42}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8, PPF = -4.75e8) annotation(
     Placement(transformation(origin = {-26, 0}, extent = {{-10, 10}, {10, -10}}, rotation = -0)));
   PowerGrids.Electrical.Buses.Bus NTLV(UNom = 21000) annotation(
-    Placement(transformation(origin = {14, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+    Placement(transformation(origin = {0, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
   PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN(R = 0.15e-2*419^2/500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2*419^2/500, rFixed = 419/21) annotation(
-    Placement(transformation(origin = {40, -20}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {24, -20}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Controls.TurbineGovernors.IEEE_TGOV1 TGOV(R = 0.05, T1 = 0.5, T2 = 3, T3 = 10, VMax = 1) annotation(
     Placement(visible = true, transformation(origin = {-62, 28}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
   PowerGrids.Electrical.Controls.ExcitationSystems.IEEE_AC4A AVR(Ka = 200, Ta = 0.05, Tb = 10, Tc = 3, VrMax = 4) annotation(
@@ -23,9 +23,9 @@ model SteadyState "Reproduces the basic static power flow, see fig. 3-1 of the r
   Modelica.Blocks.Sources.RealExpression RefLPu(y = 475/500*0.05) annotation(
     Placement(visible = true, transformation(origin = {-98, 24}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL(PRefConst = 4.75e+08, QRefConst = 7.6e+07, SNom = 5e+08, UNom = 380000, URef = 1.05*380e3) annotation(
-    Placement(transformation(origin = {76, -50}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {48, -38}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1/10, SNom = 5e+08, SSC = (2.5e+09)/1.1, UNom = 380000, URef = 1.05*380e3) annotation(
-    Placement(transformation(origin = {76, 0}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {48, 0}, extent = {{-10, -10}, {10, 10}})));
   Types.PerUnit AA_01_NGEN_U = GEN.VPu;
   Types.PerUnit AA_02_NGRID_U = GRID.port.VPu;
   Types.Angle AA_03_NGRID_delta = GRID.port.UPhase;
@@ -40,33 +40,33 @@ equation
   connect(VrefPu.y, AVR.VrefPu) annotation(
     Line(points = {{-88.8, -31}, {-89.3, -31}, {-89.3, -31}, {-85.8, -31}, {-85.8, -18}, {-79.8, -18}, {-79.8, -18}, {-71.8, -18}}, color = {0, 0, 127}));
   connect(GEN.PPu, PSS.Vsi2Pu) annotation(
-    Line(points = {{-20, 5}, {0, 5}, {0, 56}, {-130, 56}, {-130, -6}, {-108, -6}}, color = {0, 0, 127}));
+    Line(points = {{-20, 5}, {-8, 5}, {-8, 48}, {-130, 48}, {-130, -6}, {-108, -6}}, color = {0, 0, 127}));
   connect(GEN.VPu, AVR.VcPu) annotation(
-    Line(points = {{-20, 7}, {10, 7}, {10, 64}, {-140, 64}, {-140, -14}, {-72, -14}}, color = {0, 0, 127}));
+    Line(points = {{-20, 7}, {-4, 7}, {-4, 52}, {-134, 52}, {-134, -14}, {-72, -14}}, color = {0, 0, 127}));
   connect(RefLPu.y, TGOV.RefLPu) annotation(
     Line(points = {{-87, 24}, {-72, 24}}, color = {0, 0, 127}));
   connect(zero.y, AVR.VuelPu) annotation(
     Line(points = {{-88.8, -48}, {-79.8, -48}, {-79.8, -22}, {-71.8, -22}}, color = {0, 0, 127}));
   connect(GEN.omegaPu, PSS.Vsi1Pu) annotation(
-    Line(points = {{-20, 3}, {-8, 3}, {-8, 48}, {-124, 48}, {-124, 6}, {-108, 6}}, color = {0, 0, 127}));
+    Line(points = {{-20, 3}, {-12, 3}, {-12, 44}, {-124, 44}, {-124, 6}, {-108, 6}}, color = {0, 0, 127}));
   connect(PSS.VstPu, AVR.VsPu) annotation(
     Line(points = {{-87, 0}, {-76.5, 0}, {-76.5, -10}, {-72, -10}}, color = {0, 0, 127}));
   connect(AVR.efdPu, GEN.ufPuIn) annotation(
     Line(points = {{-51, -16}, {-44, -16}, {-44, 8}, {-32, 8}}, color = {0, 0, 127}));
   connect(GEN.omegaPu, TGOV.omegaPu) annotation(
-    Line(points = {{-20, 3}, {-8, 3}, {-8, 48}, {-84, 48}, {-84, 32}, {-72, 32}}, color = {0, 0, 127}));
+    Line(points = {{-20, 3}, {-12, 3}, {-12, 44}, {-84, 44}, {-84, 32}, {-72, 32}}, color = {0, 0, 127}));
   connect(TGOV.PMechPu, GEN.PmPu) annotation(
     Line(points = {{-52, 28}, {-40, 28}, {-40, 2}, {-32, 2}}, color = {0, 0, 127}));
   connect(NTLV.terminalAC, TGEN.terminalAC_a) annotation(
-    Line(points = {{14, -20}, {30, -20}}));
+    Line(points = {{0, -20}, {14, -20}}));
   connect(GEN.terminalAC, NTLV.terminalAC) annotation(
-    Line(points = {{-26, 0}, {-26, -20}, {14, -20}}));
+    Line(points = {{-26, 0}, {-26, -20}, {0, -20}}));
   connect(TGEN.terminalAC_b, GRID.terminalAC) annotation(
-    Line(points = {{50, -20}, {76, -20}, {76, 0}}));
+    Line(points = {{34, -20}, {48, -20}, {48, 0}}));
   connect(GRIDL.terminalAC, GRID.terminalAC) annotation(
-    Line(points = {{76, -50}, {76, 0}}));
+    Line(points = {{48, -38}, {48, 0}}));
   annotation(
-    Diagram(coordinateSystem(extent = {{-160, 80}, {120, -80}})),
+    Diagram(coordinateSystem(extent = {{-140, 60}, {60, -60}})),
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing");
 end SteadyState;

--- a/PowerGrids/Examples/ENTSOE/TestCase1.mo
+++ b/PowerGrids/Examples/ENTSOE/TestCase1.mo
@@ -3,7 +3,7 @@ within PowerGrids.Examples.ENTSOE;
 model TestCase1 "Test Case 1, Section 5.1, focuses on the dynamic behavior of the model for the synchronous generator machine and its AVR"
   extends Modelica.Icons.Example;
   inner PowerGrids.Electrical.System systemPowerGrids(computePF = false) annotation(
-    Placement(transformation(origin = {42, 62}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {18, 40}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8) annotation(
     Placement(transformation(origin = {-26, 0}, extent = {{-10, 10}, {10, -10}}, rotation = -0)));
   PowerGrids.Electrical.Buses.ReferenceBus NTLV(SNom = 5e+08, UNom = 21000) annotation(
@@ -24,9 +24,9 @@ model TestCase1 "Test Case 1, Section 5.1, focuses on the dynamic behavior of th
   Types.PerUnit AA_02_GEN_efd = GEN.ufPuIn "Fig. 5.2, excitation voltage";
 equation
   connect(GEN.PPu, PSS.Vsi2Pu) annotation(
-    Line(points = {{-20, 5}, {0, 5}, {0, 56}, {-130, 56}, {-130, -6}, {-108, -6}}, color = {0, 0, 127}));
+    Line(points = {{-20, 5}, {-8, 5}, {-8, 48}, {-124, 48}, {-124, -6}, {-108, -6}}, color = {0, 0, 127}));
   connect(GEN.VPu, AVR.VcPu) annotation(
-    Line(points = {{-20, 7}, {10, 7}, {10, 64}, {-138, 64}, {-138, -14}, {-72, -14}}, color = {0, 0, 127}));
+    Line(points = {{-20, 7}, {-4, 7}, {-4, 52}, {-128, 52}, {-128, -14}, {-72, -14}}, color = {0, 0, 127}));
   connect(RefLPu.y, TGOV.RefLPu) annotation(
     Line(points = {{-87, 24}, {-72, 24}}, color = {0, 0, 127}));
   connect(VrefPu.y, AVR.VrefPu) annotation(
@@ -34,19 +34,19 @@ equation
   connect(zero.y, AVR.VuelPu) annotation(
     Line(points = {{-88.8, -48}, {-79.8, -48}, {-79.8, -22}, {-71.8, -22}}, color = {0, 0, 127}));
   connect(GEN.omegaPu, PSS.Vsi1Pu) annotation(
-    Line(points = {{-20, 3}, {-8, 3}, {-8, 48}, {-124, 48}, {-124, 6}, {-108, 6}}, color = {0, 0, 127}));
+    Line(points = {{-20, 3}, {-12, 3}, {-12, 44}, {-120, 44}, {-120, 6}, {-108, 6}}, color = {0, 0, 127}));
   connect(PSS.VstPu, AVR.VsPu) annotation(
     Line(points = {{-87, 0}, {-76.5, 0}, {-76.5, -10}, {-72, -10}}, color = {0, 0, 127}));
   connect(AVR.efdPu, GEN.ufPuIn) annotation(
     Line(points = {{-51, -16}, {-44, -16}, {-44, 8}, {-32, 8}}, color = {0, 0, 127}));
   connect(GEN.omegaPu, TGOV.omegaPu) annotation(
-    Line(points = {{-20, 3}, {-8, 3}, {-8, 48}, {-84, 48}, {-84, 32}, {-72, 32}}, color = {0, 0, 127}));
+    Line(points = {{-20, 3}, {-12, 3}, {-12, 44}, {-84, 44}, {-84, 32}, {-72, 32}}, color = {0, 0, 127}));
   connect(TGOV.PMechPu, GEN.PmPu) annotation(
     Line(points = {{-52, 28}, {-40, 28}, {-40, 2}, {-32, 2}}, color = {0, 0, 127}));
   connect(GEN.terminalAC, NTLV.terminalAC) annotation(
     Line(points = {{-26, 0}, {-26, -20}, {24, -20}}));
   annotation(
-    Diagram(coordinateSystem(extent = {{-160, 80}, {60, -60}})),
+    Diagram(coordinateSystem(extent = {{-140, 60}, {40, -60}})),
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing");
 end TestCase1;

--- a/PowerGrids/Examples/ENTSOE/TestCase2.mo
+++ b/PowerGrids/Examples/ENTSOE/TestCase2.mo
@@ -18,7 +18,7 @@ model TestCase2 "Test Case 2, Section 5.2, focuses on the dynamic behavior of th
     Placement(transformation(origin = {-62, -31}, extent = {{-12, -11}, {12, 11}})));
   Modelica.Blocks.Sources.RealExpression RefLPu(y = 380/475*0.05) annotation(
     Placement(transformation(origin = {-56, 12}, extent = {{-10, -10}, {10, 10}})));
-  PowerGrids.Electrical.Loads.LoadImpedancePQInputs LOAD(SNom = 475000000, UNom = 21000) annotation(
+  PowerGrids.Electrical.Loads.LoadImpedancePQInputs LOAD(SNom = 475e6, UNom = 21000) annotation(
     Placement(transformation(origin = {68, -44}, extent = {{-10, -10}, {10, 10}})));
   Modelica.Blocks.Sources.Step PLoad(height = 23.75e6, offset = 380e6, startTime = 0.1) annotation(
     Placement(transformation(origin = {28, -40}, extent = {{-8, -8}, {8, 8}})));

--- a/PowerGrids/Examples/ENTSOE/TestCase2.mo
+++ b/PowerGrids/Examples/ENTSOE/TestCase2.mo
@@ -3,58 +3,58 @@ within PowerGrids.Examples.ENTSOE;
 model TestCase2 "Test Case 2, Section 5.2, focuses on the dynamic behavior of the model for the synchronous generator and its governor"
   extends Modelica.Icons.Example;
   inner PowerGrids.Electrical.System systemPowerGrids(computePF = false) annotation(
-    Placement(transformation(origin = {50, 30}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {62, 24}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, SNom = 4.75e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8) annotation(
-    Placement(transformation(origin = {-26, 0}, extent = {{-10, 10}, {10, -10}}, rotation = -0)));
+    Placement(transformation(origin = {16, -6}, extent = {{-10, 10}, {10, -10}})));
   PowerGrids.Electrical.Buses.ReferenceBus NGEN(SNom = 5e+08, UNom = 21000) annotation(
-    Placement(visible = true, transformation(origin = {24, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+    Placement(transformation(origin = {60, -26}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
   PowerGrids.Electrical.Controls.TurbineGovernors.IEEE_TGOV1 TGOV(R = 0.05, T1 = 0.5, T2 = 3, T3 = 10, VMax = 1) annotation(
-    Placement(visible = true, transformation(origin = {-62, 28}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
+    Placement(transformation(origin = {-20, 16}, extent = {{-10, 10}, {10, -10}})));
   PowerGrids.Electrical.Controls.ExcitationSystems.IEEE_AC4A AVR(Ka = 200, Ta = 0.05, Tb = 10, Tc = 3, VrMax = 4) annotation(
-    Placement(visible = true, transformation(origin = {-62, -16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {-20, -22}, extent = {{-10, -10}, {10, 10}})));
   Modelica.Blocks.Sources.RealExpression zero annotation(
-    Placement(transformation(origin = {-104, -40}, extent = {{-12, -10}, {12, 10}})));
+    Placement(transformation(origin = {-62, -46}, extent = {{-12, -10}, {12, 10}})));
   Modelica.Blocks.Sources.RealExpression VrefPu(y = 1.00943) annotation(
-    Placement(visible = true, transformation(origin = {-104, -25}, extent = {{-12, -11}, {12, 11}}, rotation = 0)));
+    Placement(transformation(origin = {-62, -31}, extent = {{-12, -11}, {12, 11}})));
   Modelica.Blocks.Sources.RealExpression RefLPu(y = 380/475*0.05) annotation(
-    Placement(visible = true, transformation(origin = {-98, 24}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {-56, 12}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Loads.LoadImpedancePQInputs LOAD(SNom = 475000000, UNom = 21000) annotation(
-    Placement(visible = true, transformation(origin = {32, -38}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {68, -44}, extent = {{-10, -10}, {10, 10}})));
   Modelica.Blocks.Sources.Step PLoad(height = 23.75e6, offset = 380e6, startTime = 0.1) annotation(
-    Placement(visible = true, transformation(origin = {-8, -34}, extent = {{-8, -8}, {8, 8}}, rotation = 0)));
+    Placement(transformation(origin = {28, -40}, extent = {{-8, -8}, {8, 8}})));
   Modelica.Blocks.Sources.RealExpression zero2 annotation(
-    Placement(visible = true, transformation(origin = {-8, -62}, extent = {{-12, -10}, {12, 10}}, rotation = 0)));
+    Placement(transformation(origin = {28, -66}, extent = {{-12, -10}, {12, 10}})));
   Types.PerUnit AA_01_GEN_UPu = GEN.port.VPu "Fig. 5-3, terminal voltage";
   Types.PerUnit AA_02_GEN_PPu = GEN.port.PGenPu "Fig. 5-4, active power of the synchronous machine";
   Types.PerUnit AA_03_GEN_PmechPu = GEN.PmPu "Fig. 5-5, mechanical power of the synchronous machine";
   Types.PerUnit AA_04_GEN_omegaPu = GEN.omegaPu "Fig. 5-6, speed";
 equation
   connect(GEN.VPu, AVR.VcPu) annotation(
-    Line(points = {{-20, 7}, {0, 7}, {0, 52}, {-120, 52}, {-120, -14}, {-72, -14}}, color = {0, 0, 127}));
+    Line(points = {{22, 1}, {32, 1}, {32, 34}, {-72, 34}, {-72, -20}, {-30, -20}}, color = {0, 0, 127}));
   connect(zero2.y, LOAD.QRefIn) annotation(
-    Line(points = {{6, -62}, {10, -62}, {10, -48}, {22, -48}, {22, -48}}, color = {0, 0, 127}));
+    Line(points = {{41.2, -66}, {45.4, -66}, {45.4, -54}, {57.4, -54}}, color = {0, 0, 127}));
   connect(zero.y, AVR.VuelPu) annotation(
-    Line(points = {{-91, -40}, {-79.8, -40}, {-79.8, -22}, {-71.8, -22}}, color = {0, 0, 127}));
+    Line(points = {{-48.8, -46}, {-37.6, -46}, {-37.6, -28}, {-29.6, -28}}, color = {0, 0, 127}));
   connect(zero.y, AVR.VsPu) annotation(
-    Line(points = {{-91, -40}, {-80, -40}, {-80, -10}, {-72, -10}}, color = {0, 0, 127}));
+    Line(points = {{-48.8, -46}, {-37.8, -46}, {-37.8, -16}, {-29.8, -16}}, color = {0, 0, 127}));
   connect(VrefPu.y, AVR.VrefPu) annotation(
-    Line(points = {{-91, -25}, {-85.8, -25}, {-85.8, -18}, {-71.8, -18}}, color = {0, 0, 127}));
+    Line(points = {{-48.8, -31}, {-43.6, -31}, {-43.6, -24}, {-29.6, -24}}, color = {0, 0, 127}));
   connect(PLoad.y, LOAD.PRefIn) annotation(
-    Line(points = {{1, -34}, {10, -34}, {10, -42}, {22, -42}}, color = {0, 0, 127}));
+    Line(points = {{36.8, -40}, {45.8, -40}, {45.8, -48}, {57.8, -48}}, color = {0, 0, 127}));
   connect(NGEN.terminalAC, LOAD.terminalAC) annotation(
-    Line(points = {{24, -20}, {32, -20}, {32, -38}}));
+    Line(points = {{60, -26}, {68, -26}, {68, -44}}));
   connect(RefLPu.y, TGOV.RefLPu) annotation(
-    Line(points = {{-87, 24}, {-72, 24}}, color = {0, 0, 127}));
+    Line(points = {{-45, 12}, {-30, 12}}, color = {0, 0, 127}));
   connect(AVR.efdPu, GEN.ufPuIn) annotation(
-    Line(points = {{-51, -16}, {-44, -16}, {-44, 8}, {-32, 8}}, color = {0, 0, 127}));
+    Line(points = {{-9, -22}, {-2, -22}, {-2, 2}, {10, 2}}, color = {0, 0, 127}));
   connect(GEN.omegaPu, TGOV.omegaPu) annotation(
-    Line(points = {{-20, 3}, {-8, 3}, {-8, 44}, {-84, 44}, {-84, 32}, {-72, 32}}, color = {0, 0, 127}));
+    Line(points = {{22, -3}, {28, -3}, {28, 30}, {-36, 30}, {-36, 20}, {-30, 20}}, color = {0, 0, 127}));
   connect(TGOV.PMechPu, GEN.PmPu) annotation(
-    Line(points = {{-52, 28}, {-40, 28}, {-40, 2}, {-32, 2}}, color = {0, 0, 127}));
+    Line(points = {{-10, 16}, {2, 16}, {2, -4}, {10, -4}}, color = {0, 0, 127}));
   connect(GEN.terminalAC, NGEN.terminalAC) annotation(
-    Line(points = {{-26, 0}, {-26, -20}, {24, -20}}));
+    Line(points = {{16, -6}, {16, -26}, {60, -26}}));
   annotation(
-    Diagram(coordinateSystem(extent = {{-140, 60}, {80, -80}})),
+    Diagram(coordinateSystem(extent = {{-80, -80}, {80, 40}})),
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing");
 end TestCase2;

--- a/PowerGrids/Examples/ENTSOE/TestCase3.mo
+++ b/PowerGrids/Examples/ENTSOE/TestCase3.mo
@@ -3,31 +3,31 @@ within PowerGrids.Examples.ENTSOE;
 model TestCase3 "Test Case 3, Section 5.3, focuses on the dynamic behavior of the model for the synchronous machine with its whole control in response to a short-circuit"
   extends Modelica.Icons.Example;
   inner PowerGrids.Electrical.System systemPowerGrids annotation(
-    Placement(visible = true, transformation(origin = {130, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {48, 40}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Machines.SynchronousMachine4Windings GEN(H = 4, PPF = -4.75e+08, SNom = 5e+08, Tpd0 = 5.143, Tppd0 = 0.042, Tppq0 = 0.083, Tpq0 = 2.16, UNom = 21000, raPu = 0, xdPu = 2, xlPu = 0.15, xpdPu = 0.35, xppdPu = 0.25, xppqPu = 0.3, xpqPu = 0.5, xqPu = 1.8) annotation(
-    Placement(transformation(origin = {-26, 0}, extent = {{-10, 10}, {10, -10}}, rotation = -0)));
+    Placement(transformation(origin = {-18, 0}, extent = {{-10, 10}, {10, -10}})));
   PowerGrids.Electrical.Buses.Bus NTLV(UNom = 21000) annotation(
-    Placement(visible = true, transformation(origin = {24, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
+    Placement(transformation(origin = {8, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
   PowerGrids.Electrical.Branches.TransformerFixedRatio TGEN(R = 0.15e-2*419^2/500, SNom = 5e+08, UNomA = 21000, UNomB = 419000, X = 16e-2*419^2/500, rFixed = 419/21) annotation(
-    Placement(visible = true, transformation(origin = {54, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {30, -20}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Controls.TurbineGovernors.IEEE_TGOV1 TGOV(R = 0.05, T1 = 0.5, T2 = 3, T3 = 10, VMax = 1) annotation(
-    Placement(visible = true, transformation(origin = {-62, 28}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
+    Placement(transformation(origin = {-54, 28}, extent = {{-10, 10}, {10, -10}})));
   PowerGrids.Electrical.Controls.ExcitationSystems.IEEE_AC4A AVR(Ka = 200, Ta = 0.05, Tb = 10, Tc = 3, VrMax = 4) annotation(
-    Placement(visible = true, transformation(origin = {-62, -16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {-54, -16}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Controls.PowerSystemStabilizers.IEEE_PSS2A PSS(Ks1 = 10, Ks2 = 0.1564, M = 0, N = 0, T1 = 0.25, T2 = 0.03, T3 = 0.15, T4 = 0.015, T7 = 2, T8 = 0.5, T9 = 0.1, Tw1 = 2, Tw2 = 2, Tw3 = 2, Tw4 = 0, VstMax = 0.1, VstMin = -0.1) annotation(
-    Placement(visible = true, transformation(origin = {-98, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {-90, 0}, extent = {{-10, -10}, {10, 10}})));
   Modelica.Blocks.Sources.RealExpression zero annotation(
-    Placement(visible = true, transformation(origin = {-102, -48}, extent = {{-12, -10}, {12, 10}}, rotation = 0)));
+    Placement(transformation(origin = {-94, -48}, extent = {{-12, -10}, {12, 10}})));
   Modelica.Blocks.Sources.RealExpression VrefPu(y = 1.004552) annotation(
-    Placement(visible = true, transformation(origin = {-102, -31}, extent = {{-12, -11}, {12, 11}}, rotation = 0)));
+    Placement(transformation(origin = {-94, -31}, extent = {{-12, -11}, {12, 11}})));
   Modelica.Blocks.Sources.RealExpression RefLPu(y = 475/500*0.05) annotation(
-    Placement(visible = true, transformation(origin = {-98, 24}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(transformation(origin = {-90, 24}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Loads.LoadImpedancePQ GRIDL(PRef = 4.75e+08, QRef = 7.6e+07, SNom = 500000000, UNom = 380000, URef = 1.05*380e3) annotation(
-    Placement(transformation(origin = {90, -50}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {66, -34}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Buses.EquivalentGrid GRID(R_X = 1/10, SNom = 5e+08, SSC = (2.5e+09)/1.1, UNom = 380000, URef = 1.050*380e3) annotation(
-    Placement(transformation(origin = {90, -10}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {66, -10}, extent = {{-10, -10}, {10, 10}})));
   PowerGrids.Electrical.Faults.ThreePhaseFault FAULT(R = 0.05, SNom = 5e+08, UNom = 380000, X = 0, startTime = 0.1, stopTime = 0.2) annotation(
-    Placement(transformation(origin = {112, -50}, extent = {{-10, -10}, {10, 10}})));
+    Placement(transformation(origin = {86, -34}, extent = {{-10, -10}, {10, 10}})));
   Types.PerUnit AA_01_GEN_Upu = GEN.port.VPu "Fig. 5.7, terminal voltage";
   Types.PerUnit AA_02_GEN_efd = GEN.ufPuIn "Fig. 5.8, excitation voltage";
   Types.PerUnit AA_03_GEN_Ppu = GEN.port.PGenPu/0.95 "Fig. 5.9, active power of the synchronous machine";
@@ -38,37 +38,37 @@ model TestCase3 "Test Case 3, Section 5.3, focuses on the dynamic behavior of th
   Types.PerUnit AA_08_GRIDL_Qpu = GRIDL.port.QPu/0.1519 "Fig. 5.14, reactive power of the load";
 equation
   connect(VrefPu.y, AVR.VrefPu) annotation(
-    Line(points = {{-88.8, -31}, {-89.3, -31}, {-89.3, -31}, {-85.8, -31}, {-85.8, -18}, {-79.8, -18}, {-79.8, -18}, {-71.8, -18}}, color = {0, 0, 127}));
+    Line(points = {{-80.8, -31}, {-81.3, -31}, {-81.3, -31}, {-77.8, -31}, {-77.8, -18}, {-71.8, -18}, {-71.8, -18}, {-63.8, -18}}, color = {0, 0, 127}));
   connect(GEN.PPu, PSS.Vsi2Pu) annotation(
-    Line(points = {{-20, 5}, {0, 5}, {0, 56}, {-128, 56}, {-128, -6}, {-108, -6}}, color = {0, 0, 127}));
+    Line(points = {{-12, 5}, {-4, 5}, {-4, 50}, {-112, 50}, {-112, -6}, {-100, -6}}, color = {0, 0, 127}));
   connect(GEN.VPu, AVR.VcPu) annotation(
-    Line(points = {{-20, 7}, {10, 7}, {10, 66}, {-134, 66}, {-134, -14}, {-72, -14}}, color = {0, 0, 127}));
+    Line(points = {{-12, 7}, {0, 7}, {0, 54}, {-116, 54}, {-116, -14}, {-64, -14}}, color = {0, 0, 127}));
   connect(RefLPu.y, TGOV.RefLPu) annotation(
-    Line(points = {{-87, 24}, {-72, 24}}, color = {0, 0, 127}));
+    Line(points = {{-79, 24}, {-64, 24}}, color = {0, 0, 127}));
   connect(zero.y, AVR.VuelPu) annotation(
-    Line(points = {{-88.8, -48}, {-79.8, -48}, {-79.8, -22}, {-71.8, -22}}, color = {0, 0, 127}));
+    Line(points = {{-80.8, -48}, {-71.8, -48}, {-71.8, -22}, {-63.8, -22}}, color = {0, 0, 127}));
   connect(GEN.omegaPu, PSS.Vsi1Pu) annotation(
-    Line(points = {{-20, 3}, {-8, 3}, {-8, 48}, {-124, 48}, {-124, 6}, {-108, 6}}, color = {0, 0, 127}));
+    Line(points = {{-12, 3}, {-8, 3}, {-8, 46}, {-108, 46}, {-108, 6}, {-100, 6}}, color = {0, 0, 127}));
   connect(PSS.VstPu, AVR.VsPu) annotation(
-    Line(points = {{-87, 0}, {-76.5, 0}, {-76.5, -10}, {-72, -10}}, color = {0, 0, 127}));
+    Line(points = {{-79, 0}, {-68.5, 0}, {-68.5, -10}, {-64, -10}}, color = {0, 0, 127}));
   connect(AVR.efdPu, GEN.ufPuIn) annotation(
-    Line(points = {{-51, -16}, {-44, -16}, {-44, 8}, {-32, 8}}, color = {0, 0, 127}));
+    Line(points = {{-43, -16}, {-36, -16}, {-36, 8}, {-24, 8}}, color = {0, 0, 127}));
   connect(GEN.omegaPu, TGOV.omegaPu) annotation(
-    Line(points = {{-20, 3}, {-8, 3}, {-8, 48}, {-84, 48}, {-84, 32}, {-72, 32}}, color = {0, 0, 127}));
+    Line(points = {{-12, 3}, {-8, 3}, {-8, 46}, {-76, 46}, {-76, 32}, {-64, 32}}, color = {0, 0, 127}));
   connect(TGOV.PMechPu, GEN.PmPu) annotation(
-    Line(points = {{-52, 28}, {-40, 28}, {-40, 2}, {-32, 2}}, color = {0, 0, 127}));
+    Line(points = {{-44, 28}, {-32, 28}, {-32, 2}, {-24, 2}}, color = {0, 0, 127}));
   connect(NTLV.terminalAC, TGEN.terminalAC_a) annotation(
-    Line(points = {{24, -20}, {44, -20}}));
+    Line(points = {{8, -20}, {20, -20}}));
   connect(GEN.terminalAC, NTLV.terminalAC) annotation(
-    Line(points = {{-26, 0}, {-26, -20}, {24, -20}}));
+    Line(points = {{-18, 0}, {-18, -20}, {8, -20}}));
   connect(TGEN.terminalAC_b, GRID.terminalAC) annotation(
-    Line(points = {{64, -20}, {90, -20}, {90, -10}, {90, -10}}));
+    Line(points = {{40, -20}, {66, -20}, {66, -10}, {66, -10}}));
   connect(GRIDL.terminalAC, GRID.terminalAC) annotation(
-    Line(points = {{90, -50}, {90, -10}}));
+    Line(points = {{66, -34}, {66, -10}}));
   connect(FAULT.terminalAC, GRID.terminalAC) annotation(
-    Line(points = {{112, -50}, {112, -20}, {90, -20}, {90, -10}}));
+    Line(points = {{86, -34}, {86, -20}, {66, -20}, {66, -10}}));
   annotation(
-    Diagram(coordinateSystem(extent = {{-140, 80}, {140, -80}})),
+    Diagram(coordinateSystem(extent = {{-120, 60}, {100, -60}})),
     experiment(StartTime = 0, StopTime = 2, Tolerance = 1e-6, Interval = 0.004),
     __OpenModelica_commandLineOptions = "--daeMode --tearingMethod=minimalTearing");
 end TestCase3;

--- a/PowerGrids/Examples/IEEE14bus/IEEE14busPowerFlow.mo
+++ b/PowerGrids/Examples/IEEE14bus/IEEE14busPowerFlow.mo
@@ -405,31 +405,31 @@ model IEEE14busPowerFlow "Power flow model of the IEEE 14-bus benchmark"
   PowerGrids.Electrical.PowerFlow.PVBus GEN1(
     SNom = 1211e6,
     UNom = 24e3,
-    P = -229.29e6
+    P = -229.29e6, U = 24000
   ) annotation(
     Placement(transformation(origin = {-130, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 180)));
   PowerGrids.Electrical.PowerFlow.PVBus GEN2(
     SNom = 1120e6,
     UNom = 24e3,
-    P = -40e6
+    P = -40e6, U = 24000
   ) annotation(
     Placement(visible = true, transformation(origin = {-170, -90}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
   PowerGrids.Electrical.PowerFlow.PVBus GEN3(
     SNom = 1650e6,
     UNom = 20e3,
-    P = 0.0
+    P = 0.0, U = 2e4
   ) annotation(
     Placement(visible = true, transformation(origin = {190, -90}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
   PowerGrids.Electrical.PowerFlow.PVBus GEN6(
     SNom = 80.0e6,
     UNom = 13.8e3,
-    P = 0
+    P = 0, U = 13800
   ) annotation(
     Placement(transformation(origin = {-70, 10}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
   PowerGrids.Electrical.PowerFlow.PVBus GEN8(
     SNom = 250e6,
     UNom = 18e3,
-    P = 0
+    P = 0, U = 18000
   ) annotation(
     Placement(visible = true, transformation(origin = {180, -36}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 


### PR DESCRIPTION
this PR will: 
1. reduce empty spaces around diagrams (favours better space exploitation while in plotting perspective)
2. make a minimal change on the TGOV icon
3. add literal constant U in PV nodes to allow re-simulate in OpenModelica
4. make cosmetic changes to render numbers easier to read. E.g. 500000000 -> 500e6